### PR TITLE
Add recent turn history screen

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -92,6 +92,7 @@ import com.example.alias.ui.WordCardAction
 import com.example.alias.data.settings.SettingsRepository
 private const val MIN_TEAMS = SettingsRepository.MIN_TEAMS
 private const val MAX_TEAMS = SettingsRepository.MAX_TEAMS
+private const val HISTORY_LIMIT = 50
 
 
 
@@ -169,7 +170,9 @@ class MainActivity : ComponentActivity() {
                     }
                     composable("history") {
                         AppScaffold(title = stringResource(R.string.title_history), onBack = { nav.popBackStack() }, snackbarHostState = snack) {
-                            HistoryScreen(vm)
+                            val historyFlow = remember { vm.recentHistory(HISTORY_LIMIT) }
+                            val history by historyFlow.collectAsState(initial = emptyList())
+                            HistoryScreen(history)
                         }
                     }
                     composable("about") {
@@ -825,7 +828,7 @@ private fun RoundSummaryScreen(vm: MainViewModel, s: GameState.TurnFinished) {
                         Icon(
                             if (o.correct) Icons.Filled.Check else Icons.Filled.Close,
                             contentDescription = null,
-                            tint = if (o.correct) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+                            tint = if (o.correct) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.error
                         )
                     },
                     headlineContent = { Text(o.word) },

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -53,6 +53,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.alias.ui.AppScaffold
+import com.example.alias.ui.HistoryScreen
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.OutlinedTextField
@@ -72,6 +73,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.LibraryBooks
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material.icons.filled.BugReport
@@ -133,7 +135,8 @@ class MainActivity : ComponentActivity() {
                             HomeScreen(
                                 onQuickPlay = { vm.restartMatch(); nav.navigate("game") },
                                 onDecks = { nav.navigate("decks") },
-                                onSettings = { nav.navigate("settings") }
+                                onSettings = { nav.navigate("settings") },
+                                onHistory = { nav.navigate("history") }
                             )
                         }
                     }
@@ -164,6 +167,11 @@ class MainActivity : ComponentActivity() {
                             )
                         }
                     }
+                    composable("history") {
+                        AppScaffold(title = stringResource(R.string.title_history), onBack = { nav.popBackStack() }, snackbarHostState = snack) {
+                            HistoryScreen(vm)
+                        }
+                    }
                     composable("about") {
                         AppScaffold(title = stringResource(R.string.title_about), onBack = { nav.popBackStack() }, snackbarHostState = snack) {
                             AboutScreen()
@@ -176,7 +184,12 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-private fun HomeScreen(onQuickPlay: () -> Unit, onDecks: () -> Unit, onSettings: () -> Unit) {
+private fun HomeScreen(
+    onQuickPlay: () -> Unit,
+    onDecks: () -> Unit,
+    onSettings: () -> Unit,
+    onHistory: () -> Unit,
+) {
     val colors = MaterialTheme.colorScheme
     Column(
         modifier = Modifier
@@ -216,6 +229,14 @@ private fun HomeScreen(onQuickPlay: () -> Unit, onDecks: () -> Unit, onSettings:
             onClick = onSettings,
             containerColor = colors.tertiaryContainer,
             contentColor = colors.onTertiaryContainer
+        )
+        HomeActionCard(
+            icon = Icons.Filled.History,
+            title = stringResource(R.string.title_history),
+            subtitle = stringResource(R.string.history_subtitle),
+            onClick = onHistory,
+            containerColor = colors.surfaceVariant,
+            contentColor = colors.onSurfaceVariant
         )
     }
 }

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -7,6 +7,7 @@ import com.example.alias.data.DeckRepository
 import com.example.alias.data.db.WordDao
 import com.example.alias.data.download.PackDownloader
 import com.example.alias.data.TurnHistoryRepository
+import com.example.alias.data.db.TurnHistoryEntity
 import com.example.alias.domain.DefaultGameEngine
 import com.example.alias.domain.GameEngine
 import com.example.alias.domain.MatchConfig
@@ -22,6 +23,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -55,6 +57,9 @@ class MainViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
     val settings = settingsRepository.settings
         .stateIn(viewModelScope, SharingStarted.Lazily, Settings())
+
+    fun recentHistory(limit: Int): Flow<List<TurnHistoryEntity>> =
+        historyRepository.getRecent(limit)
 
     
 

--- a/app/src/main/java/com/example/alias/ui/HistoryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/HistoryScreen.kt
@@ -14,19 +14,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ListItem
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.example.alias.MainViewModel
+import com.example.alias.data.db.TurnHistoryEntity
 import com.example.alias.R
 
 @Composable
-fun HistoryScreen(vm: MainViewModel, limit: Int = 50) {
-    val history by vm.recentHistory(limit).collectAsState(initial = emptyList())
+fun HistoryScreen(history: List<TurnHistoryEntity>) {
     if (history.isEmpty()) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(stringResource(R.string.no_history))
@@ -45,7 +41,7 @@ fun HistoryScreen(vm: MainViewModel, limit: Int = 50) {
                         Icon(
                             if (entry.correct) Icons.Filled.Check else Icons.Filled.Close,
                             contentDescription = null,
-                            tint = if (entry.correct) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+                            tint = if (entry.correct) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.error
                         )
                     }
                 )

--- a/app/src/main/java/com/example/alias/ui/HistoryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/HistoryScreen.kt
@@ -1,0 +1,56 @@
+package com.example.alias.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ListItem
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.alias.MainViewModel
+import com.example.alias.R
+
+@Composable
+fun HistoryScreen(vm: MainViewModel, limit: Int = 50) {
+    val history by vm.recentHistory(limit).collectAsState(initial = emptyList())
+    if (history.isEmpty()) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(stringResource(R.string.no_history))
+        }
+    } else {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            items(history) { entry ->
+                ListItem(
+                    headlineContent = { Text(entry.word) },
+                    supportingContent = { Text(entry.team) },
+                    trailingContent = {
+                        Icon(
+                            if (entry.correct) Icons.Filled.Check else Icons.Filled.Close,
+                            contentDescription = null,
+                            tint = if (entry.correct) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error
+                        )
+                    }
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="title_game">Game</string>
     <string name="title_decks">Decks</string>
     <string name="title_settings">Settings</string>
+    <string name="title_history">History</string>
     <string name="title_about">About</string>
     <string name="back">Back</string>
     <string name="loading">Loading…</string>
@@ -10,6 +11,7 @@
     <string name="quick_play_subtitle">Start a match with current settings</string>
     <string name="decks_subtitle">Manage and import word decks</string>
     <string name="settings_subtitle">Time, teams, language and more</string>
+    <string name="history_subtitle">Review recent turns</string>
     <string name="idle">Idle</string>
     <string name="team_label">Team: %s</string>
     <string name="remaining_label">Remaining %d</string>
@@ -31,4 +33,5 @@
     <string name="next_team">Next Team</string>
     <string name="turn_summary">Turn summary for %s</string>
     <string name="score_change">Score change: %d</string>
+    <string name="no_history">No history yet</string>
 </resources>

--- a/data/src/main/java/com/example/alias/data/TurnHistoryRepository.kt
+++ b/data/src/main/java/com/example/alias/data/TurnHistoryRepository.kt
@@ -2,9 +2,11 @@ package com.example.alias.data
 
 import com.example.alias.data.db.TurnHistoryDao
 import com.example.alias.data.db.TurnHistoryEntity
+import kotlinx.coroutines.flow.Flow
 
 interface TurnHistoryRepository {
     suspend fun save(entries: List<TurnHistoryEntity>)
+    fun getRecent(limit: Int): Flow<List<TurnHistoryEntity>>
 }
 
 class TurnHistoryRepositoryImpl(
@@ -13,5 +15,7 @@ class TurnHistoryRepositoryImpl(
     override suspend fun save(entries: List<TurnHistoryEntity>) {
         dao.insertAll(entries)
     }
+
+    override fun getRecent(limit: Int): Flow<List<TurnHistoryEntity>> = dao.getRecent(limit)
 }
 

--- a/data/src/main/java/com/example/alias/data/db/TurnHistoryDao.kt
+++ b/data/src/main/java/com/example/alias/data/db/TurnHistoryDao.kt
@@ -2,10 +2,15 @@ package com.example.alias.data.db
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface TurnHistoryDao {
     @Insert
     suspend fun insertAll(entries: List<TurnHistoryEntity>)
+
+    @Query("SELECT * FROM turn_history ORDER BY id DESC LIMIT :limit")
+    fun getRecent(limit: Int): Flow<List<TurnHistoryEntity>>
 }
 


### PR DESCRIPTION
## Summary
- query and repository to fetch recent turn history
- expose history flow in MainViewModel
- History screen with navigation entry

## Testing
- `./gradlew domain:test`
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_b_68c5900b67f8832cb10c8cee1db34c88