### PR TITLE
[app] add swipe tutorial overlay

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -728,7 +728,7 @@ private fun SettingsScreen(vm: MainViewModel, onBack: () -> Unit, onAbout: () ->
         }
         item {
             OutlinedButton(
-                onClick = { scope.launch { vm.updateSeenTutorial(false) } },
+                onClick = { vm.updateSeenTutorial(false) },
                 modifier = Modifier.fillMaxWidth()
             ) { Text(stringResource(R.string.show_tutorial_again)) }
         }

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -159,6 +159,10 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun updateSeenTutorial(value: Boolean) {
+        viewModelScope.launch { settingsRepository.updateSeenTutorial(value) }
+    }
+
     fun downloadPackFromUrl(url: String, expectedSha256: String?) {
         viewModelScope.launch {
             _uiEvents.tryEmit(UiEvent(message = "Downloading…", duration = SnackbarDuration.Indefinite))

--- a/app/src/main/java/com/example/alias/ui/TutorialOverlay.kt
+++ b/app/src/main/java/com/example/alias/ui/TutorialOverlay.kt
@@ -1,0 +1,46 @@
+package com.example.alias.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.alias.R
+
+@Composable
+fun TutorialOverlay(onDismiss: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.6f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(24.dp)
+                .background(MaterialTheme.colorScheme.surface, MaterialTheme.shapes.medium)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(R.string.tutorial_instructions),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center
+            )
+            Button(onClick = onDismiss) { Text(stringResource(R.string.tutorial_dismiss)) }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/alias/ui/TutorialOverlay.kt
+++ b/app/src/main/java/com/example/alias/ui/TutorialOverlay.kt
@@ -2,9 +2,7 @@ package com.example.alias.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -12,23 +10,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import com.example.alias.R
 
 @Composable
 fun TutorialOverlay(onDismiss: () -> Unit) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.6f)),
-        contentAlignment = Alignment.Center
-    ) {
+    Dialog(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
-                .padding(24.dp)
                 .background(MaterialTheme.colorScheme.surface, MaterialTheme.shapes.medium)
                 .padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -43,4 +35,3 @@ fun TutorialOverlay(onDismiss: () -> Unit) {
         }
     }
 }
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,4 +31,7 @@
     <string name="next_team">Next Team</string>
     <string name="turn_summary">Turn summary for %s</string>
     <string name="score_change">Score change: %d</string>
+    <string name="tutorial_instructions">Swipe right for Correct, left for Skip.</string>
+    <string name="tutorial_dismiss">Got it</string>
+    <string name="show_tutorial_again">Show tutorial again</string>
 </resources>

--- a/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
+++ b/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
@@ -35,6 +35,8 @@ interface SettingsRepository {
     // Trusted pack sources (hosts or origins) for manual downloads
     suspend fun setTrustedSources(origins: Set<String>)
 
+    suspend fun updateSeenTutorial(value: Boolean)
+
     companion object {
         const val MIN_TEAMS = 2
         const val MAX_TEAMS = 6
@@ -56,6 +58,7 @@ data class Settings(
     val oneHandedLayout: Boolean = false,
     val orientation: String = "system",
     val trustedSources: Set<String> = emptySet(),
+    val seenTutorial: Boolean = false,
 )
 
 class SettingsRepositoryImpl(
@@ -80,6 +83,7 @@ class SettingsRepositoryImpl(
             oneHandedLayout = p[Keys.ONE_HANDED] ?: false,
             orientation = p[Keys.ORIENTATION] ?: "system",
             trustedSources = p[Keys.TRUSTED_SOURCES] ?: emptySet(),
+            seenTutorial = p[Keys.SEEN_TUTORIAL] ?: false,
         )
     }
 
@@ -148,6 +152,10 @@ class SettingsRepositoryImpl(
         dataStore.edit { it[Keys.TRUSTED_SOURCES] = origins }
     }
 
+    override suspend fun updateSeenTutorial(value: Boolean) {
+        dataStore.edit { it[Keys.SEEN_TUTORIAL] = value }
+    }
+
     private object Keys {
         val ROUND_SECONDS = intPreferencesKey("round_seconds")
         val TARGET_WORDS = intPreferencesKey("target_words")
@@ -163,5 +171,6 @@ class SettingsRepositoryImpl(
         val ORIENTATION = stringPreferencesKey("orientation_mode")
         val TEAMS = stringPreferencesKey("teams")
         val TRUSTED_SOURCES = stringSetPreferencesKey("trusted_sources")
+        val SEEN_TUTORIAL = booleanPreferencesKey("seen_tutorial")
     }
 }


### PR DESCRIPTION
## Summary
- persist seenTutorial flag in SettingsRepository
- show swipe instructions overlay on first game
- allow resetting tutorial from settings

## Testing
- `./gradlew domain:test`
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_b_68c5900e960c832c969800418b383bd5