### PR TITLE
[app] Add UI language setting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,10 +19,10 @@
 - Difficulty filter: added min/max difficulty in Settings (stored) and filtering in word queries; UI controls under Decks → Filters.
 - Display word info: show difficulty and category chips during turns.
 - Category filters: added persistent category selection, filter chips in Decks → Filters, applied in queries and word metadata.
+- Add UI localization setting for English and Russian.
 
 ## Backlog
-- Add ui localization setting English and Russian
-- Add word info to db, like, difficulty, category, and word classes. Display it on card and make filters in deck menu to filter words out 
+- Add word info to db, like, difficulty, category, and word classes. Display it on card and make filters in deck menu to filter words out
   - Partially done: uses existing difficulty/category; added difficulty filter. Consider category and word-class filters next.
 - Bundled assets change detection: implemented; consider per-deck id tracking and pruning removed assets.
 - Room migrations: implement proper migrations for DB version upgrades; remove destructive fallback in production builds.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.activity:activity-compose:1.8.2")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
+    implementation("androidx.appcompat:appcompat:1.6.1")
 
     val composeBom = platform("androidx.compose:compose-bom:2024.02.00")
     implementation(composeBom)

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -299,6 +299,7 @@ class MainViewModel @Inject constructor(
         penaltyPerSkip: Int,
         punishSkips: Boolean,
         language: String,
+        uiLanguage: String,
         allowNSFW: Boolean,
         haptics: Boolean,
         sound: Boolean,
@@ -319,6 +320,7 @@ class MainViewModel @Inject constructor(
         settingsRepository.updateOneHandedLayout(oneHanded)
         settingsRepository.updateVerticalSwipes(verticalSwipes)
         settingsRepository.updateOrientation(orientation)
+        settingsRepository.updateUiLanguage(uiLanguage)
         // Language validation may fail; keep others applied regardless
         val langResult = runCatching { settingsRepository.updateLanguagePreference(language) }
         if (langResult.isFailure) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -68,6 +68,10 @@
     <string name="haptics_label">Виброотклик</string>
     <string name="sound_effects_label">Звуковые эффекты</string>
     <string name="one_hand_layout_label">Удобно одной рукой</string>
+    <string name="ui_language_label">Язык интерфейса</string>
+    <string name="system_default_label">Системный</string>
+    <string name="english_label">Английский</string>
+    <string name="russian_label">Русский</string>
     <string name="orientation_label">Ориентация</string>
     <string name="auto_label">Авто</string>
     <string name="portrait_label">Портрет</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,10 @@
     <string name="haptics_label">Haptics</string>
     <string name="sound_effects_label">Sound effects</string>
     <string name="one_hand_layout_label">One-hand layout</string>
+    <string name="ui_language_label">UI language</string>
+    <string name="system_default_label">System</string>
+    <string name="english_label">English</string>
+    <string name="russian_label">Russian</string>
     <string name="orientation_label">Orientation</string>
     <string name="auto_label">Auto</string>
     <string name="portrait_label">Portrait</string>

--- a/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
+++ b/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
@@ -32,6 +32,7 @@ interface SettingsRepository {
     suspend fun updateSoundEnabled(value: Boolean)
     suspend fun updateOneHandedLayout(value: Boolean)
     suspend fun updateOrientation(value: String)
+    suspend fun updateUiLanguage(language: String)
     suspend fun updateDifficultyFilter(min: Int, max: Int)
     suspend fun setCategoriesFilter(categories: Set<String>)
     suspend fun setTeams(teams: List<String>)
@@ -60,6 +61,7 @@ data class Settings(
     val penaltyPerSkip: Int = 1,
     val punishSkips: Boolean = true,
     val languagePreference: String = "en",
+    val uiLanguage: String = "system",
     val enabledDeckIds: Set<String> = emptySet(),
     val teams: List<String> = DEFAULT_TEAMS,
     val allowNSFW: Boolean = false,
@@ -88,6 +90,7 @@ class SettingsRepositoryImpl(
             penaltyPerSkip = p[Keys.PENALTY_PER_SKIP] ?: 1,
             punishSkips = p[Keys.PUNISH_SKIPS] ?: true,
             languagePreference = p[Keys.LANGUAGE] ?: "en",
+            uiLanguage = p[Keys.UI_LANGUAGE] ?: "system",
             enabledDeckIds = p[Keys.ENABLED_DECK_IDS] ?: emptySet(),
             teams = p[Keys.TEAMS]?.split("|")?.filter { it.isNotBlank() }?.take(SettingsRepository.MAX_TEAMS)?.let {
                 if (it.size >= SettingsRepository.MIN_TEAMS) it else DEFAULT_TEAMS
@@ -165,6 +168,14 @@ class SettingsRepositoryImpl(
         dataStore.edit { it[Keys.ORIENTATION] = norm }
     }
 
+    override suspend fun updateUiLanguage(language: String) {
+        val norm = when (language.lowercase()) {
+            "system", "en", "ru" -> language.lowercase()
+            else -> "system"
+        }
+        dataStore.edit { it[Keys.UI_LANGUAGE] = norm }
+    }
+
     override suspend fun updateDifficultyFilter(min: Int, max: Int) {
         val lo = min.coerceIn(1, 5)
         val hi = max.coerceIn(1, 5)
@@ -216,6 +227,7 @@ class SettingsRepositoryImpl(
         val PENALTY_PER_SKIP = intPreferencesKey("penalty_per_skip")
         val PUNISH_SKIPS = booleanPreferencesKey("punish_skips")
         val LANGUAGE = stringPreferencesKey("language_preference")
+        val UI_LANGUAGE = stringPreferencesKey("ui_language")
         val ENABLED_DECK_IDS = stringSetPreferencesKey("enabled_deck_ids")
         val ALLOW_NSFW = booleanPreferencesKey("allow_nsfw")
         val STEMMING_ENABLED = booleanPreferencesKey("stemming_enabled")

--- a/data/src/test/java/com/example/alias/data/download/PackDownloaderTest.kt
+++ b/data/src/test/java/com/example/alias/data/download/PackDownloaderTest.kt
@@ -29,6 +29,7 @@ private class FakeSettingsRepo(origins: Set<String>) : SettingsRepository {
     override suspend fun updateHapticsEnabled(value: Boolean) = Unit
     override suspend fun updateOneHandedLayout(value: Boolean) = Unit
     override suspend fun updateOrientation(value: String) = Unit
+    override suspend fun updateUiLanguage(language: String) = Unit
     override suspend fun setTeams(teams: List<String>) = Unit
     override suspend fun updatePunishSkips(value: Boolean) = Unit
     override suspend fun setTrustedSources(origins: Set<String>) { flow.value = flow.value.copy(trustedSources = origins) }


### PR DESCRIPTION
## Summary
- add persistent UI language preference and AppCompat locale switching
- expose English/Russian/System options in Settings screen
- localize new strings and update settings repository

## Testing
- `./gradlew domain:test` *(fails: process hung after `:domain:test`)*
- `./gradlew assembleDebug` *(fails: process hung after `:app:mergeExtDexDebug`)*

------
https://chatgpt.com/codex/tasks/task_b_68c6c60bfb9c832c915cfef2188fd964