### PR TITLE
Add composite index for language/NSFW word filtering

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@
  - Normalize trusted source input and surface invalid host/origin.
  - Surface language validation errors via snackbar.
  - Add Reset local data (clears DB + preferences) with confirmation.
-- Add indices for faster word queries; bump DB version.
+- Add indices for faster word queries, including composite language/NSFW index; bump DB version.
 - Auto-enable decks matching new language with Undo prompt in Settings.
 - Show last word after timer ends and allow marking it in the summary without over-penalizing.
 - Localize remaining visible literals (Home, Game chips, About).
@@ -28,7 +28,6 @@
 - Room migrations: implement proper migrations for DB version upgrades; remove destructive fallback in production builds.
 - Localization: complete pass for any residual literals (e.g., minor labels) to `strings.xml`.
 - Make sure that last shown word is also visible in screen after time ends and you can also mark last shown word.
-- Performance: add indices for `words(language, isNSFW)` to accelerate filtered queries.
 - Tests:
   - Repository: verify re-import of the same deck does not duplicate words (and that updated decks replace content).
   - App-layer: verify last-turn outcomes are persisted when match ends (target reached or timer with no words left).

--- a/data/schemas/com.example.alias.data.db.AliasDatabase/4.json
+++ b/data/schemas/com.example.alias.data.db.AliasDatabase/4.json
@@ -1,0 +1,214 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "fe09c224670300ff774f427db5060acf",
+    "entities": [
+      {
+        "tableName": "decks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `language` TEXT NOT NULL, `isOfficial` INTEGER NOT NULL, `isNSFW` INTEGER NOT NULL, `version` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOfficial",
+            "columnName": "isOfficial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNSFW",
+            "columnName": "isNSFW",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "words",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `deckId` TEXT NOT NULL, `text` TEXT NOT NULL, `language` TEXT NOT NULL, `stems` TEXT, `category` TEXT, `difficulty` INTEGER NOT NULL, `tabooStems` TEXT, `isNSFW` INTEGER NOT NULL, FOREIGN KEY(`deckId`) REFERENCES `decks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deckId",
+            "columnName": "deckId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stems",
+            "columnName": "stems",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "difficulty",
+            "columnName": "difficulty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabooStems",
+            "columnName": "tabooStems",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isNSFW",
+            "columnName": "isNSFW",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_words_deckId",
+            "unique": false,
+            "columnNames": [
+              "deckId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_words_deckId` ON `${TABLE_NAME}` (`deckId`)"
+          },
+          {
+            "name": "index_words_language_isNSFW",
+            "unique": false,
+            "columnNames": [
+              "language",
+              "isNSFW"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_words_language_isNSFW` ON `${TABLE_NAME}` (`language`, `isNSFW`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "decks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "deckId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "turn_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `team` TEXT NOT NULL, `word` TEXT NOT NULL, `correct` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "team",
+            "columnName": "team",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correct",
+            "columnName": "correct",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fe09c224670300ff774f427db5060acf')"
+    ]
+  }
+}

--- a/data/src/main/java/com/example/alias/data/db/AliasDatabase.kt
+++ b/data/src/main/java/com/example/alias/data/db/AliasDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 
 @Database(
     entities = [DeckEntity::class, WordEntity::class, TurnHistoryEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 abstract class AliasDatabase : RoomDatabase() {

--- a/data/src/main/java/com/example/alias/data/db/WordEntity.kt
+++ b/data/src/main/java/com/example/alias/data/db/WordEntity.kt
@@ -16,7 +16,7 @@ import androidx.room.PrimaryKey
             onDelete = ForeignKey.CASCADE
         )
     ],
-    indices = [Index("deckId"), Index("language"), Index("isNSFW")]
+    indices = [Index("deckId"), Index(value = ["language", "isNSFW"])]
 )
 data class WordEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,


### PR DESCRIPTION
## Summary
- add composite Room index on words(language, isNSFW)
- bump AliasDatabase version to 4 and update Room schema
- document the completed performance task in TODO

## Testing
- `./gradlew domain:test`
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_b_68c75c8e00a8832cb590b0d1eec3cff0