### PR TITLE
Use placeholder while game engine loads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     implementation(libs.bundles.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.accompanist.placeholder.material3)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -71,6 +71,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Add
@@ -108,6 +109,7 @@ import com.example.alias.ui.TutorialOverlay
 import com.example.alias.data.settings.SettingsRepository
 import com.example.alias.data.db.DeckEntity
 import androidx.compose.ui.platform.LocalUriHandler
+import com.google.accompanist.placeholder.material3.placeholder
 private const val MIN_TEAMS = SettingsRepository.MIN_TEAMS
 private const val MAX_TEAMS = SettingsRepository.MAX_TEAMS
 private const val HISTORY_LIMIT = 50
@@ -179,9 +181,11 @@ class MainActivity : ComponentActivity() {
                         val settings by vm.settings.collectAsState()
                         AppScaffold(title = stringResource(R.string.title_game), onBack = { nav.popBackStack() }, snackbarHostState = snack) {
                             if (engine == null) {
-                                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                    Text(stringResource(R.string.loading))
-                                }
+                                Surface(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .placeholder(true)
+                                ) {}
                             } else {
                                 GameScreen(vm, engine!!, settings)
                             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ datastore-preferences = "1.1.1"
 okhttp = "4.12.0"
 detekt = "1.23.8"
 spotless = "6.25.0"
+accompanist = "0.34.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
@@ -47,6 +48,7 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 okhttp-tls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref = "okhttp" }
+accompanist-placeholder-material3 = { group = "com.google.accompanist", name = "accompanist-placeholder-material3", version.ref = "accompanist" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }


### PR DESCRIPTION
## Summary
- add accompanist placeholder dependency
- show placeholder surface while game engine initializes

## Testing
- `./gradlew domain:test` *(fails: unresolved dependencies / timeout)*
- `./gradlew assembleDebug` *(fails: unresolved dependencies / timeout)*

------
https://chatgpt.com/codex/tasks/task_b_68c80242465c832ca1cdf8d582fd8b12