### PR TITLE
[app] Apply stored locale at startup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
         android:name=".AliasApp"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher">
+        android:roundIcon="@mipmap/ic_launcher"
+        android:localeConfig="@xml/locales_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/alias/AliasApp.kt
+++ b/app/src/main/java/com/example/alias/AliasApp.kt
@@ -7,37 +7,63 @@ import com.example.alias.data.settings.SettingsRepository
 import dagger.hilt.android.HiltAndroidApp
 import java.util.Locale
 import javax.inject.Inject
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @HiltAndroidApp
 class AliasApp : Application() {
     @Inject lateinit var settingsRepository: SettingsRepository
 
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
     override fun onCreate() {
         super.onCreate()
-        runBlocking {
-            val stored = settingsRepository.settings.first().uiLanguage
+        applicationScope.launch {
+            val storedRaw = withContext(Dispatchers.IO) { settingsRepository.settings.first().uiLanguage }
+            val stored = canonicalizeLanguageSetting(storedRaw)
+            if (storedRaw != stored) {
+                settingsRepository.updateUiLanguage(stored)
+            }
+
             val appLocales = AppCompatDelegate.getApplicationLocales()
-            val systemTag = if (appLocales.isEmpty) "system" else appLocales.toLanguageTags()
-            val tag = if (systemTag != "system") systemTag else stored
+            val appTag = if (appLocales.isEmpty) "system" else canonicalizeLanguageSetting(appLocales.toLanguageTags())
+            val tag = if (appTag != "system") appTag else stored
             if (stored != tag) {
                 settingsRepository.updateUiLanguage(tag)
             }
-            val locales = when (tag) {
-                "system" -> LocaleListCompat.getEmptyLocaleList()
-                else -> LocaleListCompat.forLanguageTags(tag)
+
+            val locales = if (tag == "system") {
+                LocaleListCompat.getEmptyLocaleList()
+            } else {
+                LocaleListCompat.forLanguageTags(tag)
             }
             if (appLocales != locales) {
                 AppCompatDelegate.setApplicationLocales(locales)
             }
+
             val defaultLocale = if (locales.isEmpty) {
-                LocaleListCompat.getAdjustedDefault()[0]
+                LocaleListCompat.getAdjustedDefault().get(0)
             } else {
-                locales[0]
+                locales.get(0)
             }
-            defaultLocale?.let { Locale.setDefault(it) }
+            defaultLocale?.let(Locale::setDefault)
         }
+    }
+
+    private fun canonicalizeLanguageSetting(raw: String): String {
+        val trimmed = raw.trim()
+        if (trimmed.equals("system", ignoreCase = true) || trimmed.isEmpty()) {
+            return "system"
+        }
+        val locales = LocaleListCompat.forLanguageTags(trimmed)
+        if (locales.isEmpty) {
+            return "system"
+        }
+        return locales.toLanguageTags()
     }
 }
 

--- a/app/src/main/java/com/example/alias/AliasApp.kt
+++ b/app/src/main/java/com/example/alias/AliasApp.kt
@@ -1,7 +1,43 @@
 package com.example.alias
 
 import android.app.Application
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import com.example.alias.data.settings.SettingsRepository
 import dagger.hilt.android.HiltAndroidApp
+import java.util.Locale
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.first
 
 @HiltAndroidApp
-class AliasApp : Application()
+class AliasApp : Application() {
+    @Inject lateinit var settingsRepository: SettingsRepository
+
+    override fun onCreate() {
+        super.onCreate()
+        runBlocking {
+            val stored = settingsRepository.settings.first().uiLanguage
+            val appLocales = AppCompatDelegate.getApplicationLocales()
+            val systemTag = if (appLocales.isEmpty) "system" else appLocales.toLanguageTags()
+            val tag = if (systemTag != "system") systemTag else stored
+            if (stored != tag) {
+                settingsRepository.updateUiLanguage(tag)
+            }
+            val locales = when (tag) {
+                "system" -> LocaleListCompat.getEmptyLocaleList()
+                else -> LocaleListCompat.forLanguageTags(tag)
+            }
+            if (appLocales != locales) {
+                AppCompatDelegate.setApplicationLocales(locales)
+            }
+            val defaultLocale = if (locales.isEmpty) {
+                LocaleListCompat.getAdjustedDefault()[0]
+            } else {
+                locales[0]
+            }
+            defaultLocale?.let { Locale.setDefault(it) }
+        }
+    }
+}
+

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="ru" />
+</locale-config>


### PR DESCRIPTION
## Summary
- apply stored UI language on startup and sync with system app-language
- expose supported languages to Android's system-level language picker

## Testing
- `./gradlew domain:test`
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_b_68c827e19b30832c9ff90eee96091ba2