### PR TITLE
Enlarge start turn button in pending turn state

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -445,7 +445,17 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(stringResource(R.string.team_label, s.team))
-                Button(onClick = { vm.startTurn() }) { Text(stringResource(R.string.start_turn)) }
+                Button(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(80.dp),
+                    onClick = { vm.startTurn() }
+                ) {
+                    Text(
+                        text = stringResource(R.string.start_turn),
+                        style = MaterialTheme.typography.headlineMedium
+                    )
+                }
             }
         }
         is GameState.TurnActive -> {


### PR DESCRIPTION
## Summary
- expand the pending turn start button to span the width with added height for easier tapping
- increase the start turn label typography to headlineMedium for better readability

## Testing
- ./gradlew --console=plain spotlessApply
- ./gradlew --console=plain detekt
- ./gradlew --console=plain :app:testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_b_68c9703d5c48832c9a439a9c26dd829c