### PR TITLE
Add countdown overlay before starting turn

### DIFF
--- a/app/src/main/java/com/example/alias/ui/CountdownOverlay.kt
+++ b/app/src/main/java/com/example/alias/ui/CountdownOverlay.kt
@@ -1,0 +1,26 @@
+package com.example.alias.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun CountdownOverlay(value: Int, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.7f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = value.toString(),
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `CountdownOverlay` composable for the pre-turn countdown
- start turns via a LaunchedEffect-driven countdown in `GameScreen`
- keep the start button disabled while the countdown runs to avoid double starts

## Testing
- ./gradlew --console=plain spotlessApply
- ./gradlew --console=plain detekt
- ./gradlew --console=plain :domain:test :data:test :app:testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_b_68c9703d8634832c9a1f54f0df37958b