### PR TITLE
Update home screen branding

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -275,9 +275,7 @@ private fun HomeScreen(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 horizontalAlignment = Alignment.Start
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    HomeLogo(size = 72.dp)
-                }
+                HomeLogo(size = 72.dp)
                 HomeActionCard(
                     icon = Icons.Filled.PlayArrow,
                     title = stringResource(R.string.quick_play),
@@ -376,7 +374,7 @@ private fun HomeLogo(size: Dp, modifier: Modifier = Modifier) {
         Box(contentAlignment = Alignment.Center) {
             Icon(
                 painter = painterResource(id = R.drawable.ic_launcher_foreground_asset),
-                contentDescription = null,
+                contentDescription = stringResource(R.string.app_name),
                 modifier = Modifier.fillMaxSize(0.6f)
             )
         }

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -103,7 +104,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.text.KeyboardOptions
 import kotlinx.coroutines.launch
 import com.example.alias.ui.WordCard
@@ -113,6 +113,7 @@ import com.example.alias.data.settings.SettingsRepository
 import com.example.alias.data.db.DeckEntity
 import androidx.compose.ui.platform.LocalUriHandler
 import com.google.accompanist.placeholder.material3.placeholder
+import androidx.compose.ui.unit.Dp
 private const val MIN_TEAMS = SettingsRepository.MIN_TEAMS
 private const val MAX_TEAMS = SettingsRepository.MAX_TEAMS
 private const val HISTORY_LIMIT = 50
@@ -275,8 +276,7 @@ private fun HomeScreen(
                 horizontalAlignment = Alignment.Start
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Image(painterResource(id = R.drawable.ic_launcher_foreground_asset), contentDescription = null, modifier = Modifier.size(48.dp))
-                    Text(text = stringResource(R.string.app_name), style = MaterialTheme.typography.displaySmall, color = colors.primary)
+                    HomeLogo(size = 72.dp)
                 }
                 HomeActionCard(
                     icon = Icons.Filled.PlayArrow,
@@ -327,12 +327,7 @@ private fun HomeScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // App title / branding
-            Image(painterResource(id = R.drawable.ic_launcher_foreground_asset), contentDescription = null, modifier = Modifier.size(56.dp))
-            Text(
-                text = stringResource(R.string.app_name),
-                style = MaterialTheme.typography.displaySmall,
-                color = colors.primary
-            )
+            HomeLogo(size = 96.dp)
             // Primary actions as sleek cards
             HomeActionCard(
                 icon = Icons.Filled.PlayArrow,
@@ -365,6 +360,24 @@ private fun HomeScreen(
                 onClick = onHistory,
                 containerColor = colors.tertiaryContainer,
                 contentColor = colors.onTertiaryContainer
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeLogo(size: Dp, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.size(size),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.primary
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_launcher_foreground_asset),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(0.6f)
             )
         }
     }


### PR DESCRIPTION
## Summary
- remove the title text from the home screen in both landscape and portrait orientations
- enlarge the home logo and render it in Material colors for better prominence

## Testing
- ./gradlew --console=plain spotlessApply
- ./gradlew --console=plain detekt

------
https://chatgpt.com/codex/tasks/task_b_68c9703f04c8832c890e3f5a36f6f444