### PR TITLE
Address review feedback for start turn button sizing

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -113,6 +113,8 @@ import com.example.alias.data.settings.SettingsRepository
 import com.example.alias.data.db.DeckEntity
 import androidx.compose.ui.platform.LocalUriHandler
 import com.google.accompanist.placeholder.material3.placeholder
+
+private val LARGE_BUTTON_HEIGHT = 80.dp
 private const val MIN_TEAMS = SettingsRepository.MIN_TEAMS
 private const val MAX_TEAMS = SettingsRepository.MAX_TEAMS
 private const val HISTORY_LIMIT = 50
@@ -446,10 +448,10 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
             ) {
                 Text(stringResource(R.string.team_label, s.team))
                 Button(
+                    onClick = { vm.startTurn() },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(80.dp),
-                    onClick = { vm.startTurn() }
+                        .height(LARGE_BUTTON_HEIGHT)
                 ) {
                     Text(
                         text = stringResource(R.string.start_turn),
@@ -622,12 +624,12 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
                             Button(
                                 onClick = onCorrect,
                                 enabled = !isProcessing,
-                                modifier = Modifier.fillMaxWidth().height(80.dp)
+                                modifier = Modifier.fillMaxWidth().height(LARGE_BUTTON_HEIGHT)
                             ) { Icon(Icons.Filled.Check, contentDescription = null); Spacer(Modifier.width(8.dp)); Text(stringResource(R.string.correct)) }
                             Button(
                                 onClick = onSkip,
                                 enabled = !isProcessing && s.skipsRemaining > 0,
-                                modifier = Modifier.fillMaxWidth().height(80.dp)
+                                modifier = Modifier.fillMaxWidth().height(LARGE_BUTTON_HEIGHT)
                             ) { Icon(Icons.Filled.Close, contentDescription = null); Spacer(Modifier.width(8.dp)); Text(stringResource(R.string.skip)) }
                         }
                     } else {


### PR DESCRIPTION
## Summary
- reorder the pending turn button parameters to match Compose conventions
- extract a shared LARGE_BUTTON_HEIGHT constant and reuse it for all 80dp buttons on the game screen

## Testing
- ./gradlew --console=plain spotlessApply
- ./gradlew --console=plain detekt
- ./gradlew --console=plain :app:testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_b_68c97a4a9ff4832c8860056d8db339c5