### PR TITLE
Adjust snackbar duration handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,6 +25,7 @@
 - Show placeholder while loading game content.
 - Add sound effects for word Correct and Skip with toggle in Settings.
 - Add word metadata storage (difficulty, category, classes), display chips on the word card, and provide deck filters for categories and word classes.
+- Snackbar UX: replace manual 1s autohide with built-in durations for non-indefinite events.
 
 ## Backlog
 - Bundled assets change detection: implemented; consider per-deck id tracking and pruning removed assets.
@@ -34,4 +35,3 @@
   - Repository: verify re-import of the same deck does not duplicate words (and that updated decks replace content).
   - App-layer: verify last-turn outcomes are persisted when match ends (target reached or timer with no words left).
   - Engine: property-like tests for multi-team rotation and cumulative scoring across many turns.
-- Snackbar UX: replace manual 1s autohide with appropriate built-in durations for non-indefinite events.

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -150,25 +150,20 @@ class MainActivity : AppCompatActivity() {
                 // Collect general UI events and show snackbars
                 LaunchedEffect(Unit) {
                     vm.uiEvents.collect { ev: UiEvent ->
-                        // Always show, but enforce a 1s auto-dismiss for non-indefinite events.
-                        val showJob = launch {
-                            val result = snack.showSnackbar(
-                                message = ev.message,
-                                actionLabel = ev.actionLabel,
-                                withDismissAction = ev.actionLabel == null,
-                                duration = ev.duration
-                            )
-                            if (result == SnackbarResult.ActionPerformed) {
-                                ev.onAction?.invoke()
-                            }
+                        val duration = when {
+                            ev.duration == SnackbarDuration.Indefinite -> SnackbarDuration.Indefinite
+                            ev.actionLabel != null && ev.duration == SnackbarDuration.Short -> SnackbarDuration.Long
+                            else -> ev.duration
                         }
-                        if (ev.duration != SnackbarDuration.Indefinite) {
-                            launch {
-                                kotlinx.coroutines.delay(1000)
-                                snack.currentSnackbarData?.dismiss()
-                            }
+                        val result = snack.showSnackbar(
+                            message = ev.message,
+                            actionLabel = ev.actionLabel,
+                            withDismissAction = ev.actionLabel == null,
+                            duration = duration
+                        )
+                        if (result == SnackbarResult.ActionPerformed) {
+                            ev.onAction?.invoke()
                         }
-                        showJob.join()
                     }
                 }
                 NavHost(

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -150,10 +150,10 @@ class MainActivity : AppCompatActivity() {
                 // Collect general UI events and show snackbars
                 LaunchedEffect(Unit) {
                     vm.uiEvents.collect { ev: UiEvent ->
-                        val duration = when {
-                            ev.duration == SnackbarDuration.Indefinite -> SnackbarDuration.Indefinite
-                            ev.actionLabel != null && ev.duration == SnackbarDuration.Short -> SnackbarDuration.Long
-                            else -> ev.duration
+                        val duration = if (ev.actionLabel != null && ev.duration == SnackbarDuration.Short) {
+                            SnackbarDuration.Long
+                        } else {
+                            ev.duration
                         }
                         val result = snack.showSnackbar(
                             message = ev.message,


### PR DESCRIPTION
## Summary
- rely on SnackbarDuration to manage snackbar visibility instead of a manual 1s dismissal
- extend short snackbars with actions to use the built-in long duration and update the TODO tracker

## Testing
- ./gradlew --console=plain spotlessCheck
- ./gradlew --console=plain detekt
- ./gradlew --console=plain :domain:test
- ./gradlew --console=plain :data:test
- ./gradlew --console=plain :app:testDebugUnitTest
- ./gradlew --console=plain :app:assembleDebug

------
https://chatgpt.com/codex/tasks/task_b_68caa2218b08832c9786cc68c1e74b40