### PR TITLE
Fix top app bar back button description

### DIFF
--- a/app/src/main/java/com/example/alias/ui/AppScaffold.kt
+++ b/app/src/main/java/com/example/alias/ui/AppScaffold.kt
@@ -59,7 +59,7 @@ fun AppScaffold(
                             IconButton(onClick = onBack) {
                                 Icon(
                                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                    contentDescription = ""
+                                    contentDescription = stringResource(R.string.back)
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- set the top app bar back arrow icon's content description to the localized "back" string so TalkBack announces it properly

## Testing
- `./gradlew --console=plain spotlessCheck detekt :domain:test :data:test :app:testDebugUnitTest :app:assembleDebug` *(fails: existing detekt issues in unchanged files and Gradle state tracking bug for :domain:detekt)*

------
https://chatgpt.com/codex/tasks/task_b_68caa60348e8832cbbb30361c0e5d787