### PR TITLE
Add localized countdown announcement for accessibility

### DIFF
--- a/app/src/main/java/com/example/alias/ui/CountdownOverlay.kt
+++ b/app/src/main/java/com/example/alias/ui/CountdownOverlay.kt
@@ -30,11 +30,13 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.example.alias.R
 
 /**
  * Fullscreen countdown overlay with animated ticks and accessibility announcements.
@@ -54,6 +56,8 @@ fun CountdownOverlay(
     performHaptics: Boolean = true,
 ) {
     if (value == null || value <= 0) return
+
+    val announcement = stringResource(R.string.countdown_announcement, value)
 
     val haptics = LocalHapticFeedback.current
     LaunchedEffect(value) {
@@ -87,7 +91,7 @@ fun CountdownOverlay(
             )
             // Screen reader announces each tick.
             .semantics {
-                contentDescription = "Countdown: $value"
+                contentDescription = announcement
                 liveRegion = LiveRegionMode.Assertive
             },
         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/example/alias/ui/CountdownOverlay.kt
+++ b/app/src/main/java/com/example/alias/ui/CountdownOverlay.kt
@@ -93,6 +93,7 @@ fun CountdownOverlay(
             .semantics {
                 contentDescription = announcement
                 liveRegion = LiveRegionMode.Assertive
+                mergeDescendants = true
             },
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -16,6 +16,7 @@
     <string name="idle">Ожидание</string>
     <string name="team_label">Команда: %s</string>
     <string name="remaining_label">Осталось %d</string>
+    <string name="countdown_announcement">Обратный отсчёт: %1$d</string>
     <plurals name="score_label">
         <item quantity="one">%d очко</item>
         <item quantity="few">%d очка</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="idle">Idle</string>
     <string name="team_label">Team: %s</string>
     <string name="remaining_label">Remaining %d</string>
+    <string name="countdown_announcement">Countdown: %1$d</string>
     <plurals name="score_label">
         <item quantity="one">%d point</item>
         <item quantity="other">%d points</item>


### PR DESCRIPTION
## Summary
- add a formatted countdown announcement string in English and Russian resources
- announce the countdown overlay using the localized string resource for TalkBack

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68caa609b5f8832c8e9cfdfb6b625936