### PR TITLE
Add localized timer countdown plurals

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -630,7 +630,15 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
                 }
             }
             val Controls: @Composable () -> Unit = {
-                Text("${s.timeRemaining}s", style = MaterialTheme.typography.headlineLarge, textAlign = TextAlign.Center)
+                Text(
+                    pluralStringResource(
+                        R.plurals.time_remaining_seconds,
+                        s.timeRemaining,
+                        s.timeRemaining
+                    ),
+                    style = MaterialTheme.typography.headlineLarge,
+                    textAlign = TextAlign.Center
+                )
                 Text(stringResource(R.string.team_label, s.team), style = MaterialTheme.typography.titleMedium)
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     AssistChip(onClick = {}, enabled = false, label = { Text(stringResource(R.string.remaining_label, s.remaining)) })

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -28,6 +28,12 @@
         <item quantity="many">%d пропусков</item>
         <item quantity="other">%d пропуска</item>
     </plurals>
+    <plurals name="time_remaining_seconds">
+        <item quantity="one">%d секунда</item>
+        <item quantity="few">%d секунды</item>
+        <item quantity="many">%d секунд</item>
+        <item quantity="other">%d секунды</item>
+    </plurals>
     <string name="summary_label">Осталось: %1$d • Очки: %2$d • Пропуски: %3$d</string>
     <string name="correct">Правильно</string>
     <string name="skip">Пропустить</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,10 @@
         <item quantity="one">%d skip</item>
         <item quantity="other">%d skips</item>
     </plurals>
+    <plurals name="time_remaining_seconds">
+        <item quantity="one">%d second</item>
+        <item quantity="other">%d seconds</item>
+    </plurals>
     <string name="summary_label">Remaining: %1$d • Score: %2$d • Skips: %3$d</string>
     <string name="correct">Correct</string>
     <string name="skip">Skip</string>


### PR DESCRIPTION
## Summary
- add a pluralized timer string to the default resources and provide a Russian translation
- use the new plural resource in the game controls so the countdown text localizes correctly

## Testing
- ./gradlew :app:assembleDebug --console=plain --no-daemon -Pkotlin.incremental=false | tail -n 200

------
https://chatgpt.com/codex/tasks/task_b_68caa6120ab8832c89ccdc57046158a6