### PR TITLE
Use ArrayDeque for DefaultGameEngine queue

### DIFF
--- a/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
+++ b/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
@@ -22,7 +22,7 @@ class DefaultGameEngine(
     private val _state = MutableStateFlow<GameState>(GameState.Idle)
     override val state: StateFlow<GameState> = _state.asStateFlow()
 
-    private var queue: ArrayDeque<String> = ArrayDeque()
+    private lateinit var queue: ArrayDeque<String>
     private lateinit var config: MatchConfig
     private lateinit var teams: List<String>
     private val scores: MutableMap<String, Int> = mutableMapOf()

--- a/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
+++ b/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
@@ -22,7 +22,7 @@ class DefaultGameEngine(
     private val _state = MutableStateFlow<GameState>(GameState.Idle)
     override val state: StateFlow<GameState> = _state.asStateFlow()
 
-    private var queue: MutableList<String> = mutableListOf()
+    private var queue: ArrayDeque<String> = ArrayDeque()
     private lateinit var config: MatchConfig
     private lateinit var teams: List<String>
     private val scores: MutableMap<String, Int> = mutableMapOf()
@@ -45,7 +45,7 @@ class DefaultGameEngine(
         mutex.withLock {
             this@DefaultGameEngine.config = config
             this@DefaultGameEngine.teams = teams
-            queue = words.shuffled(Random(seed)).toMutableList()
+            queue = ArrayDeque(words.shuffled(Random(seed)))
             scores.clear()
             teams.forEach { scores[it] = 0 }
             correctTotal = 0


### PR DESCRIPTION
## Summary
- replace the DefaultGameEngine word queue with an ArrayDeque seeded from the shuffled word list
- continue using deque APIs for peeking and advancing turns so removals stay O(1)

## Testing
- ./gradlew :domain:test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_b_68caa64dbf98832c98468d4ea402ce2a