### PR TITLE
Show deck download progress in decks screen

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -1037,18 +1037,11 @@ private fun DeckDownloadProgressIndicator(progress: MainViewModel.DeckDownloadPr
 
     Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(statusText, style = MaterialTheme.typography.bodyMedium)
-        when (progress.step) {
-            MainViewModel.DeckDownloadStep.DOWNLOADING -> {
-                if (fraction != null) {
-                    LinearProgressIndicator(progress = fraction, modifier = Modifier.fillMaxWidth())
-                } else {
-                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                }
-            }
-
-            MainViewModel.DeckDownloadStep.IMPORTING -> {
-                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            }
+        val indicatorModifier = Modifier.fillMaxWidth()
+        if (fraction != null && progress.step == MainViewModel.DeckDownloadStep.DOWNLOADING) {
+            LinearProgressIndicator(progress = { fraction }, modifier = indicatorModifier)
+        } else {
+            LinearProgressIndicator(modifier = indicatorModifier)
         }
     }
 }

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -118,6 +118,7 @@ import com.example.alias.ui.TutorialOverlay
 import com.example.alias.data.settings.SettingsRepository
 import com.example.alias.data.db.DeckEntity
 import androidx.compose.ui.platform.LocalUriHandler
+import kotlin.math.roundToInt
 import com.google.accompanist.placeholder.material3.placeholder
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.text.font.FontWeight
@@ -150,10 +151,16 @@ class MainActivity : AppCompatActivity() {
                 // Collect general UI events and show snackbars
                 LaunchedEffect(Unit) {
                     vm.uiEvents.collect { ev: UiEvent ->
+                        if (ev.dismissCurrent) {
+                            snack.currentSnackbarData?.dismiss()
+                        }
                         val duration = if (ev.actionLabel != null && ev.duration == SnackbarDuration.Short) {
                             SnackbarDuration.Long
                         } else {
                             ev.duration
+                        }
+                        if (ev.message.isBlank()) {
+                            return@collect
                         }
                         val result = snack.showSnackbar(
                             message = ev.message,
@@ -851,6 +858,7 @@ private fun DecksScreen(vm: MainViewModel, onDeckSelected: (DeckEntity) -> Unit)
     val enabled by vm.enabledDeckIds.collectAsState()
     val trusted by vm.trustedSources.collectAsState()
     val settings by vm.settings.collectAsState()
+    val downloadProgress by vm.deckDownloadProgress.collectAsState()
     // Status snackbars are handled globally via vm.uiEvents
     var url by rememberSaveable { mutableStateOf("") }
     var sha by rememberSaveable { mutableStateOf("") }
@@ -933,6 +941,12 @@ private fun DecksScreen(vm: MainViewModel, onDeckSelected: (DeckEntity) -> Unit)
                             TextButton(onClick = { vm.setAllDecksEnabled(false) }) { Text(stringResource(R.string.disable_all)) }
                         }
                     }
+                    downloadProgress?.let {
+                        DeckDownloadProgressIndicator(progress = it)
+                        if (decks.isNotEmpty()) {
+                            HorizontalDivider()
+                        }
+                    }
                     if (decks.isEmpty()) {
                         Text(stringResource(R.string.no_decks_installed))
                     } else {
@@ -1001,6 +1015,39 @@ private fun DecksScreen(vm: MainViewModel, onDeckSelected: (DeckEntity) -> Unit)
                         OutlinedButton(onClick = { if (newTrusted.isNotBlank()) { vm.addTrustedSource(newTrusted.trim()); newTrusted = "" } }) { Text(stringResource(R.string.add)) }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeckDownloadProgressIndicator(progress: MainViewModel.DeckDownloadProgress) {
+    val totalBytes = progress.totalBytes?.takeIf { it > 0L }
+    val fraction = totalBytes?.let { bytesTotal ->
+        val clamped = progress.bytesRead.coerceAtMost(bytesTotal)
+        (clamped.toFloat() / bytesTotal.toFloat()).coerceIn(0f, 1f)
+    }
+    val statusText = when (progress.step) {
+        MainViewModel.DeckDownloadStep.DOWNLOADING -> fraction?.let {
+            stringResource(R.string.deck_download_percent, (it * 100).roundToInt())
+        } ?: stringResource(R.string.deck_download_downloading)
+
+        MainViewModel.DeckDownloadStep.IMPORTING -> stringResource(R.string.deck_download_importing)
+    }
+
+    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(statusText, style = MaterialTheme.typography.bodyMedium)
+        when (progress.step) {
+            MainViewModel.DeckDownloadStep.DOWNLOADING -> {
+                if (fraction != null) {
+                    LinearProgressIndicator(progress = fraction, modifier = Modifier.fillMaxWidth())
+                } else {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+
+            MainViewModel.DeckDownloadStep.IMPORTING -> {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             }
         }
     }

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -328,15 +328,20 @@ class MainViewModel @Inject constructor(
             )
             try {
                 val bytes = withContext(Dispatchers.IO) {
+                    var lastUpdate = 0L
                     downloader.download(
                         url.trim(),
                         expectedSha256?.trim().takeUnless { it.isNullOrEmpty() }
-                    ) { read, total ->
-                        _deckDownloadProgress.value = DeckDownloadProgress(
-                            step = DeckDownloadStep.DOWNLOADING,
-                            bytesRead = read,
-                            totalBytes = total
-                        )
+                    ) { bytesRead, totalBytes ->
+                        val now = System.currentTimeMillis()
+                        if (now - lastUpdate > 100 || (totalBytes != null && bytesRead == totalBytes)) {
+                            _deckDownloadProgress.value = DeckDownloadProgress(
+                                step = DeckDownloadStep.DOWNLOADING,
+                                bytesRead = bytesRead,
+                                totalBytes = totalBytes
+                            )
+                            lastUpdate = now
+                        }
                     }
                 }
                 // Try JSON first

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -49,6 +49,17 @@ class MainViewModel @Inject constructor(
     private val _engine = MutableStateFlow<GameEngine?>(null)
     val engine: StateFlow<GameEngine?> = _engine.asStateFlow()
 
+    enum class DeckDownloadStep { DOWNLOADING, IMPORTING }
+
+    data class DeckDownloadProgress(
+        val step: DeckDownloadStep,
+        val bytesRead: Long = 0L,
+        val totalBytes: Long? = null,
+    )
+
+    private val _deckDownloadProgress = MutableStateFlow<DeckDownloadProgress?>(null)
+    val deckDownloadProgress: StateFlow<DeckDownloadProgress?> = _deckDownloadProgress.asStateFlow()
+
     // Expose decks and enabled ids for Decks screen
     val decks = deckRepository.getDecks()
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
@@ -72,6 +83,7 @@ class MainViewModel @Inject constructor(
         val actionLabel: String? = null,
         val duration: SnackbarDuration = SnackbarDuration.Short,
         val isError: Boolean = false,
+        val dismissCurrent: Boolean = false,
         val onAction: (suspend () -> Unit)? = null,
     )
     private val _uiEvents = MutableSharedFlow<UiEvent>(
@@ -306,15 +318,51 @@ class MainViewModel @Inject constructor(
 
     fun downloadPackFromUrl(url: String, expectedSha256: String?) {
         viewModelScope.launch {
-            _uiEvents.tryEmit(UiEvent(message = "Downloading…", duration = SnackbarDuration.Indefinite))
+            _deckDownloadProgress.value = DeckDownloadProgress(step = DeckDownloadStep.DOWNLOADING)
+            _uiEvents.tryEmit(
+                UiEvent(
+                    message = "Downloading…",
+                    duration = SnackbarDuration.Short,
+                    dismissCurrent = true
+                )
+            )
             try {
-                val bytes = withContext(Dispatchers.IO) { downloader.download(url.trim(), expectedSha256?.trim().takeUnless { it.isNullOrEmpty() }) }
+                val bytes = withContext(Dispatchers.IO) {
+                    downloader.download(
+                        url.trim(),
+                        expectedSha256?.trim().takeUnless { it.isNullOrEmpty() }
+                    ) { read, total ->
+                        _deckDownloadProgress.value = DeckDownloadProgress(
+                            step = DeckDownloadStep.DOWNLOADING,
+                            bytesRead = read,
+                            totalBytes = total
+                        )
+                    }
+                }
                 // Try JSON first
                 val text = bytes.toString(Charsets.UTF_8)
+                _deckDownloadProgress.value = DeckDownloadProgress(step = DeckDownloadStep.IMPORTING)
                 withContext(Dispatchers.IO) { deckRepository.importJson(text) }
-                _uiEvents.tryEmit(UiEvent(message = "Imported deck from URL", actionLabel = "OK", duration = SnackbarDuration.Short))
+                _uiEvents.tryEmit(
+                    UiEvent(
+                        message = "Imported deck from URL",
+                        actionLabel = "OK",
+                        duration = SnackbarDuration.Short,
+                        dismissCurrent = true
+                    )
+                )
             } catch (t: Throwable) {
-                _uiEvents.tryEmit(UiEvent(message = "Failed: ${t.message}", actionLabel = "Dismiss", duration = SnackbarDuration.Long, isError = true))
+                _uiEvents.tryEmit(
+                    UiEvent(
+                        message = "Failed: ${t.message}",
+                        actionLabel = "Dismiss",
+                        duration = SnackbarDuration.Long,
+                        isError = true,
+                        dismissCurrent = true
+                    )
+                )
+            } finally {
+                _deckDownloadProgress.value = null
             }
         }
     }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -57,6 +57,9 @@
     <string name="enable_all">Вкл. все</string>
     <string name="disable_all">Выкл. все</string>
     <string name="no_decks_installed">Нет установленных колод</string>
+    <string name="deck_download_downloading">Скачивание колоды…</string>
+    <string name="deck_download_percent">Скачивание колоды… %1$d%%</string>
+    <string name="deck_download_importing">Импорт колоды…</string>
     <string name="import_download">Импорт и загрузка</string>
     <string name="import_file">Импорт файла</string>
     <string name="trust_host">Доверять хосту</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,9 @@
     <string name="enable_all">Enable all</string>
     <string name="disable_all">Disable all</string>
     <string name="no_decks_installed">No decks installed</string>
+    <string name="deck_download_downloading">Downloading deck…</string>
+    <string name="deck_download_percent">Downloading deck… %1$d%%</string>
+    <string name="deck_download_importing">Importing deck…</string>
     <string name="import_download">Import / Download</string>
     <string name="import_file">Import file</string>
     <string name="trust_host">Trust host</string>


### PR DESCRIPTION
## Summary
- add tracked deck download progress state and snackbar dismissal control in the view model
- surface progress in the decks screen with a linear indicator and localized copy for both English and Russian
- allow the downloader to report byte progress to update the UI as chunks stream in

## Testing
- ./gradlew --console=plain spotlessCheck :data:test
- ./gradlew --console=plain spotlessCheck

------
https://chatgpt.com/codex/tasks/task_b_68cbbc453154832c8e88b6415abaf8e1