### PR TITLE
Optimize initial settings loading

### DIFF
--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import androidx.compose.material3.SnackbarDuration
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -104,6 +106,11 @@ class MainViewModel @Inject constructor(
         val wordClassFilterEnabled: Int,
     )
 
+    private data class InitialLoadResult(
+        val words: List<String>,
+        val settings: Settings,
+    )
+
     private fun Settings.toWordQueryFilters(deckIdsOverride: Set<String>? = null): WordQueryFilters {
         val deckIds = (deckIdsOverride ?: enabledDeckIds).toList()
         val categories = selectedCategories.toList()
@@ -123,7 +130,7 @@ class MainViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val words = withContext(Dispatchers.IO) {
+            val initial = withContext(Dispatchers.IO) {
                 // Import bundled JSON decks from assets/decks/ when changed (by checksum) or on first run
                 val assetFiles = context.assets.list("decks")?.filter { it.endsWith(".json") } ?: emptyList()
                 val prev = settingsRepository.readBundledDeckHashes()
@@ -163,19 +170,22 @@ class MainViewModel @Inject constructor(
                 // Persist current checksums if any
                 runCatching { settingsRepository.writeBundledDeckHashes(currentEntries) }
                 // Resolve enabled deck ids; if none set, pick available decks matching language preference
-                val s0 = settingsRepository.settings.first()
+                val baseSettings = settingsRepository.settings.first()
                 val allDecks = deckRepository.getDecks().first()
-                val preferredIds = allDecks.filter { it.language == s0.languagePreference }.map { it.id }.toSet()
+                val preferredIds = allDecks.filter { it.language == baseSettings.languagePreference }.map { it.id }.toSet()
                 val fallbackIds = allDecks.map { it.id }.toSet()
-                val initialEnabled = if (s0.enabledDeckIds.isEmpty()) {
+                val resolvedEnabled = if (baseSettings.enabledDeckIds.isEmpty()) {
                     if (preferredIds.isNotEmpty()) preferredIds else fallbackIds
-                } else s0.enabledDeckIds
-                if (s0.enabledDeckIds.isEmpty()) {
-                    try { settingsRepository.setEnabledDeckIds(initialEnabled) } catch (_: Throwable) {}
+                } else baseSettings.enabledDeckIds
+                if (baseSettings.enabledDeckIds.isEmpty()) {
+                    try {
+                        settingsRepository.setEnabledDeckIds(resolvedEnabled)
+                    } catch (_: Throwable) {
+                    }
                 }
                 // Fetch words for enabled decks in preferred language
-                val filters = s0.toWordQueryFilters(initialEnabled)
-                if (filters.deckIds.isEmpty()) emptyList() else wordDao.getWordTextsForDecks(
+                val filters = baseSettings.toWordQueryFilters(resolvedEnabled)
+                val words = if (filters.deckIds.isEmpty()) emptyList() else wordDao.getWordTextsForDecks(
                     filters.deckIds,
                     filters.language,
                     filters.allowNSFW,
@@ -185,55 +195,62 @@ class MainViewModel @Inject constructor(
                     filters.categoryFilterEnabled,
                     filters.wordClasses,
                     filters.wordClassFilterEnabled
+                )
+                InitialLoadResult(
+                    words = words,
+                    settings = baseSettings.copy(enabledDeckIds = resolvedEnabled)
                 )
             }
-            // Also prepare word metadata for the same filtered set
+            // Also prepare word metadata and supporting filters for the same snapshot
             viewModelScope.launch(Dispatchers.IO) {
-                val filters = settingsRepository.settings.first().toWordQueryFilters()
-                val briefs = if (filters.deckIds.isEmpty()) emptyList() else wordDao.getWordBriefsForDecks(
-                    filters.deckIds,
-                    filters.language,
-                    filters.allowNSFW,
-                    filters.minDifficulty,
-                    filters.maxDifficulty,
-                    filters.categories,
-                    filters.categoryFilterEnabled,
-                    filters.wordClasses,
-                    filters.wordClassFilterEnabled
-                )
-                val map = briefs.associateBy({ it.text }) {
-                    WordInfo(it.difficulty, it.category, parseClass(it.wordClass))
+                val filters = initial.settings.toWordQueryFilters()
+                if (filters.deckIds.isEmpty()) {
+                    _wordInfo.value = emptyMap()
+                    _availableCategories.value = emptyList()
+                    _availableWordClasses.value = emptyList()
+                } else {
+                    coroutineScope {
+                        val briefsDeferred = async {
+                            wordDao.getWordBriefsForDecks(
+                                filters.deckIds,
+                                filters.language,
+                                filters.allowNSFW,
+                                filters.minDifficulty,
+                                filters.maxDifficulty,
+                                filters.categories,
+                                filters.categoryFilterEnabled,
+                                filters.wordClasses,
+                                filters.wordClassFilterEnabled
+                            )
+                        }
+                        val categoriesDeferred = async {
+                            wordDao.getAvailableCategories(filters.deckIds, filters.language, filters.allowNSFW)
+                        }
+                        val classesDeferred = async {
+                            wordDao.getAvailableWordClasses(filters.deckIds, filters.language, filters.allowNSFW)
+                        }
+                        val briefs = briefsDeferred.await()
+                        val categories = categoriesDeferred.await().sorted()
+                        val classes = classesDeferred.await()
+                        val map = briefs.associateBy({ it.text }) {
+                            WordInfo(it.difficulty, it.category, parseClass(it.wordClass))
+                        }
+                        _wordInfo.value = map
+                        _availableCategories.value = categories
+                        _availableWordClasses.value = WordClassCatalog.order(classes)
+                    }
                 }
-                _wordInfo.value = map
             }
-            // Load available categories for enabled decks
-            viewModelScope.launch(Dispatchers.IO) {
-                val filters = settingsRepository.settings.first().toWordQueryFilters()
-                val list = if (filters.deckIds.isEmpty()) emptyList() else wordDao.getAvailableCategories(
-                    filters.deckIds, filters.language, filters.allowNSFW
-                ).sorted()
-                _availableCategories.value = list
-            }
-            // Load available word classes
-            viewModelScope.launch(Dispatchers.IO) {
-                val filters = settingsRepository.settings.first().toWordQueryFilters()
-                val list = if (filters.deckIds.isEmpty()) emptyList() else wordDao.getAvailableWordClasses(
-                    filters.deckIds, filters.language, filters.allowNSFW
-                )
-                _availableWordClasses.value = WordClassCatalog.order(list)
-            }
-            val e = DefaultGameEngine(words, viewModelScope)
+            val e = DefaultGameEngine(initial.words, viewModelScope)
             _engine.value = e
-            // Resolve initial settings
-            val s = settingsRepository.settings.first()
             val config = MatchConfig(
-                targetWords = s.targetWords,
-                maxSkips = s.maxSkips,
-                penaltyPerSkip = if (s.punishSkips) s.penaltyPerSkip else 0,
-                roundSeconds = s.roundSeconds
+                targetWords = initial.settings.targetWords,
+                maxSkips = initial.settings.maxSkips,
+                penaltyPerSkip = if (initial.settings.punishSkips) initial.settings.penaltyPerSkip else 0,
+                roundSeconds = initial.settings.roundSeconds
             )
             val seed = java.security.SecureRandom().nextLong()
-            e.startMatch(config, teams = s.teams, seed = seed)
+            e.startMatch(config, teams = initial.settings.teams, seed = seed)
         }
     }
 


### PR DESCRIPTION
## Summary
- reuse a single initial settings snapshot when bootstrapping the game engine to avoid repeated DataStore reads
- group metadata/category/class queries so they share filters and run concurrently off the same snapshot
- build the initial MatchConfig from the cached settings instead of fetching them again

## Testing
- :app:testDebugUnitTest --console=plain *(fails: `:app:mergeDebugResources` could not delete an intermediate directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cbc4a34df0832cb129b0cc82d4a6e9