### PR TITLE
Fix snackbar queue blocking new events

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -150,6 +150,7 @@ import com.example.alias.ui.WordCardAction
 import com.google.accompanist.placeholder.material3.placeholder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Date
@@ -195,17 +196,17 @@ class MainActivity : AppCompatActivity() {
 
                 // Collect general UI events and show snackbars
                 LaunchedEffect(Unit) {
-                    vm.uiEvents.collect { ev: UiEvent ->
+                    vm.uiEvents.collectLatest { ev: UiEvent ->
                         if (ev.dismissCurrent) {
                             snack.currentSnackbarData?.dismiss()
+                        }
+                        if (ev.message.isBlank()) {
+                            return@collectLatest
                         }
                         val duration = if (ev.actionLabel != null && ev.duration == SnackbarDuration.Short) {
                             SnackbarDuration.Long
                         } else {
                             ev.duration
-                        }
-                        if (ev.message.isBlank()) {
-                            return@collect
                         }
                         val result = snack.showSnackbar(
                             message = ev.message,


### PR DESCRIPTION
## Summary
- collect UI snackbar events with collectLatest so new messages dismiss the current one immediately
- ignore empty snackbar payloads before launching a new message

## Testing
- ./gradlew spotlessCheck detekt :domain:test :data:test :app:testDebugUnitTest :app:assembleDebug --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_b_68cbe822e594832c8573e61130b3563f