### PR TITLE
Improve deck filters difficulty selection

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -1692,7 +1692,7 @@ private fun adjustDifficultyRange(current: Pair<Int, Int>, level: Int): Pair<Int
 }
 
 private fun toggleDifficultyLevel(current: IntRange, level: Int): IntRange {
-    val (min, max) = normalizeDifficultyRange(current.first, current.last)
+    val (min, max) = current.first to current.last
     val clampedLevel = level.coerceIn(DEFAULT_DIFFICULTY_RANGE.first, DEFAULT_DIFFICULTY_RANGE.last)
     val (newMin, newMax) = when {
         clampedLevel < min -> clampedLevel to max
@@ -1702,8 +1702,7 @@ private fun toggleDifficultyLevel(current: IntRange, level: Int): IntRange {
         clampedLevel == max -> min to (max - 1).coerceAtLeast(min)
         else -> clampedLevel to clampedLevel
     }
-    val (normalizedMin, normalizedMax) = normalizeDifficultyRange(newMin, newMax)
-    return normalizedMin..normalizedMax
+    return newMin..newMax
 }
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -1752,7 +1751,7 @@ private fun DifficultyFilterRow(
     onLevelToggle: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val normalizedSelection = if (selectedLevels.isEmpty()) DEFAULT_DIFFICULTY_RANGE.toSet() else selectedLevels
+    val normalizedSelection = selectedLevels
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(stringResource(R.string.difficulty_filter_label))
         FlowRow(

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -144,8 +144,7 @@
     <string name="filters_label">Фильтры</string>
     <string name="categories_label">Категории</string>
     <string name="word_classes_label">Классы слов</string>
-    <string name="min_difficulty_label">Мин. сложность</string>
-    <string name="max_difficulty_label">Макс. сложность</string>
+    <string name="difficulty_filter_label">Сложность</string>
     <string name="word_difficulty_value">Сложность %1$d</string>
     <string name="apply_label">Применить</string>
     <string name="filters_hint">Фильтры сработают в следующем матче (Перезапуск).</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,8 +179,7 @@
     <string name="filters_label">Filters</string>
     <string name="categories_label">Categories</string>
     <string name="word_classes_label">Word classes</string>
-    <string name="min_difficulty_label">Min difficulty</string>
-    <string name="max_difficulty_label">Max difficulty</string>
+    <string name="difficulty_filter_label">Difficulty</string>
     <string name="word_difficulty_value">Difficulty %1$d</string>
     <string name="apply_label">Apply</string>
     <string name="filters_hint">Filters apply to the next match (Restart).</string>


### PR DESCRIPTION
## Summary
- replace the min/max difficulty text fields in the deck filters sheet with chip controls for the five difficulty levels
- normalize and persist difficulty selections through helper range utilities when applying deck filters
- update localized strings to reflect the new difficulty chip label

## Testing
- ./gradlew spotlessApply --console=plain

------
https://chatgpt.com/codex/tasks/task_b_68cbe8f685ac832cbd1f75cf4704af46