### PR TITLE
Add turn result score sparkline and tighten timeline spacing

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -106,14 +106,18 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -1636,9 +1640,10 @@ private fun DeckCoverArt(deck: DeckEntity, modifier: Modifier = Modifier) {
             .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
             .background(gradient)
     ) {
-        if (coverImage != null) {
+        val image = coverImage
+        if (image != null) {
             Image(
-                bitmap = coverImage,
+                bitmap = image,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.matchParentSize()
@@ -2998,7 +3003,7 @@ private fun RoundSummaryScreen(vm: MainViewModel, s: GameState.TurnFinished, set
 
     Column(
         modifier = Modifier.fillMaxSize().padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
+        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
     ) {
         Text(stringResource(R.string.turn_summary, s.team), style = MaterialTheme.typography.headlineSmall)
         Text(
@@ -3022,19 +3027,23 @@ private fun RoundSummaryScreen(vm: MainViewModel, s: GameState.TurnFinished, set
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(vertical = 16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                    contentPadding = PaddingValues(vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     item {
                         Column(
                             modifier = Modifier.padding(horizontal = 20.dp),
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             Text(stringResource(R.string.turn_timeline_title), style = MaterialTheme.typography.titleMedium)
                             Text(
                                 text = stringResource(R.string.timeline_score_breakdown),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = colors.onSurfaceVariant
+                            )
+                            ScoreProgressGraph(
+                                events = timeline.events,
+                                modifier = Modifier.fillMaxWidth()
                             )
                         }
                     }
@@ -3096,6 +3105,8 @@ private data class TimelineData(
     val segments: List<TimelineSegment>,
 )
 
+private data class ScoreTimelinePoint(val time: Float, val score: Float)
+
 private fun buildTimelineData(outcomes: List<TurnOutcome>, penaltyPerSkip: Int): TimelineData {
     if (outcomes.isEmpty()) return TimelineData(emptyList(), emptyList())
     val events = mutableListOf<TimelineEvent>()
@@ -3145,6 +3156,112 @@ private fun buildTimelineData(outcomes: List<TurnOutcome>, penaltyPerSkip: Int):
     return TimelineData(events = events, segments = segments)
 }
 
+private fun buildScoreProgressPoints(events: List<TimelineEvent>): List<ScoreTimelinePoint> {
+    if (events.isEmpty()) return emptyList()
+    val hasElapsed = events.any { it.elapsedMillis > 0L }
+    return buildList {
+        add(ScoreTimelinePoint(0f, 0f))
+        events.forEachIndexed { index, event ->
+            val time = if (hasElapsed) event.elapsedMillis.toFloat() else (index + 1).toFloat()
+            add(ScoreTimelinePoint(time, event.cumulative.toFloat()))
+        }
+    }
+}
+
+@Composable
+private fun ScoreProgressGraph(events: List<TimelineEvent>, modifier: Modifier = Modifier) {
+    val points = remember(events) { buildScoreProgressPoints(events) }
+    if (points.size <= 1) return
+    val colors = MaterialTheme.colorScheme
+    val strokeColor = if (events.lastOrNull()?.cumulative ?: 0 >= 0) colors.tertiary else colors.error
+    val fillColor = strokeColor.copy(alpha = 0.2f)
+    val baselineColor = colors.outline.copy(alpha = 0.5f)
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(
+            text = stringResource(R.string.timeline_score_graph_label),
+            style = MaterialTheme.typography.labelLarge,
+            color = colors.onSurfaceVariant
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(64.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(colors.surfaceVariant.copy(alpha = 0.6f))
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        ) {
+            Canvas(Modifier.fillMaxSize()) {
+                val xMin = points.minOf { it.time }
+                val xMax = points.maxOf { it.time }
+                val xRange = (xMax - xMin)
+                val useIndex = xRange <= 0f
+                val yMin = points.minOf { it.score }
+                val yMax = points.maxOf { it.score }
+                val yRange = (yMax - yMin)
+                val offsets = points.mapIndexed { index, point ->
+                    val xFraction = if (useIndex) {
+                        if (points.lastIndex == 0) 0f else index.toFloat() / points.lastIndex.toFloat()
+                    } else {
+                        (point.time - xMin) / xRange
+                    }
+                    val yFraction = if (yRange > 0f) {
+                        (point.score - yMin) / yRange
+                    } else {
+                        0.5f
+                    }
+                    Offset(
+                        x = xFraction.coerceIn(0f, 1f) * size.width,
+                        y = size.height - yFraction.coerceIn(0f, 1f) * size.height
+                    )
+                }
+                val zeroLineY = when {
+                    yRange > 0f && yMin <= 0f && yMax >= 0f -> {
+                        val zeroFraction = (0f - yMin) / yRange
+                        size.height - zeroFraction * size.height
+                    }
+                    yRange == 0f && yMin == 0f -> size.height * 0.5f
+                    else -> null
+                }
+                if (zeroLineY != null) {
+                    drawLine(
+                        color = baselineColor,
+                        start = Offset(0f, zeroLineY),
+                        end = Offset(size.width, zeroLineY),
+                        strokeWidth = 1.dp.toPx()
+                    )
+                }
+                if (offsets.size >= 2) {
+                    val fillPath = Path().apply {
+                        moveTo(offsets.first().x, size.height)
+                        offsets.forEach { lineTo(it.x, it.y) }
+                        lineTo(offsets.last().x, size.height)
+                        close()
+                    }
+                    drawPath(
+                        path = fillPath,
+                        brush = Brush.verticalGradient(
+                            colors = listOf(fillColor, fillColor.copy(alpha = 0f)),
+                            startY = 0f,
+                            endY = size.height
+                        )
+                    )
+                    val strokePath = Path().apply {
+                        offsets.forEachIndexed { index, offset ->
+                            if (index == 0) moveTo(offset.x, offset.y) else lineTo(offset.x, offset.y)
+                        }
+                    }
+                    drawPath(
+                        path = strokePath,
+                        color = strokeColor,
+                        style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round)
+                    )
+                    drawCircle(color = strokeColor, radius = 4.dp.toPx(), center = offsets.last())
+                }
+            }
+        }
+    }
+}
+
 @Composable
 private fun TimelineSegmentHeader(
     segment: TimelineSegment,
@@ -3177,7 +3294,7 @@ private fun TimelineSegmentHeader(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(horizontal = 16.dp, vertical = 12.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -3186,7 +3303,7 @@ private fun TimelineSegmentHeader(
                 TimelineSegmentType.SKIP -> Icons.Filled.Close
                 TimelineSegmentType.PENDING -> Icons.Filled.Schedule
             }
-            Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(24.dp))
+            Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(20.dp))
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(4.dp)
@@ -3237,9 +3354,9 @@ private fun TimelineEventRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(top = 8.dp)
+            .padding(top = 4.dp)
             .height(IntrinsicSize.Min),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.Top
     ) {
         TimelineIndicator(
@@ -3249,13 +3366,19 @@ private fun TimelineEventRow(
         )
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(6.dp)
+            verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
             ) {
-                Text(event.outcome.word, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(
+                    event.outcome.word,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
                 if (event.isBonus) {
                     AssistChip(
                         onClick = {},
@@ -3271,7 +3394,7 @@ private fun TimelineEventRow(
                     )
                 }
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = stringResource(R.string.timeline_change, event.change),
                     style = MaterialTheme.typography.bodyMedium,
@@ -3301,7 +3424,7 @@ private fun TimelineEventRow(
 private fun TimelineIndicator(color: Color, showTopConnector: Boolean, showBottomConnector: Boolean) {
     Box(
         modifier = Modifier
-            .width(28.dp)
+            .width(24.dp)
             .fillMaxHeight(),
         contentAlignment = Alignment.TopCenter
     ) {

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -3200,7 +3200,7 @@ private fun ScoreProgressGraph(events: List<TimelineEvent>, modifier: Modifier =
                 val yRange = (yMax - yMin)
                 val offsets = points.mapIndexed { index, point ->
                     val xFraction = if (useIndex) {
-                        if (points.lastIndex == 0) 0f else index.toFloat() / points.lastIndex.toFloat()
+                        index.toFloat() / points.lastIndex.toFloat()
                     } else {
                         (point.time - xMin) / xRange
                     }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -66,7 +66,40 @@
     <string name="end_match">Завершить матч</string>
     <string name="next_team">Следующая команда</string>
     <string name="turn_summary">Ход: %s</string>
-    <string name="score_change">Изменение: %d</string>
+    <string name="score_change">Изменение счёта: %+d</string>
+    <string name="turn_timeline_title">Хронология хода</string>
+    <string name="timeline_score_breakdown">Посмотрите, как команда набрала очки в этом раунде.</string>
+    <string name="timeline_score_graph_label">Очки по времени</string>
+    <string name="timeline_no_events">В этом ходу слова не записывались.</string>
+    <string name="timeline_bonus_label">Бонус</string>
+    <string name="timeline_change">%1$+d</string>
+    <string name="timeline_running_total">Текущий итог %1$+d</string>
+    <string name="timeline_elapsed_time">Прошло %1$.1f с от начала хода</string>
+    <string name="timeline_elapsed_time_start">Начало хода</string>
+    <string name="timeline_header_correct_subtitle">%1$+d за серию</string>
+    <string name="timeline_header_penalty_subtitle">Влияние %1$+d</string>
+    <string name="timeline_header_pending_subtitle">Счёт пока без изменений</string>
+    <string name="timeline_header_skip_no_penalty">Штраф не применён</string>
+    <string name="timeline_mark_correct">Отметить как верное</string>
+    <string name="timeline_mark_incorrect">Отметить как неверное</string>
+    <plurals name="timeline_correct">
+        <item quantity="one">Верное слово</item>
+        <item quantity="few">Серия верных ×%d</item>
+        <item quantity="many">Серия верных ×%d</item>
+        <item quantity="other">Серия верных ×%d</item>
+    </plurals>
+    <plurals name="timeline_skipped">
+        <item quantity="one">Пропущенное слово</item>
+        <item quantity="few">Пропущенные слова ×%d</item>
+        <item quantity="many">Пропущенные слова ×%d</item>
+        <item quantity="other">Пропущенные слова ×%d</item>
+    </plurals>
+    <plurals name="timeline_pending">
+        <item quantity="one">Ожидающее слово</item>
+        <item quantity="few">Ожидающие слова ×%d</item>
+        <item quantity="many">Ожидающие слова ×%d</item>
+        <item quantity="other">Ожидающие слова ×%d</item>
+    </plurals>
     <string name="tutorial_instructions">Вправо — верно, влево — пропуск.</string>
     <string name="tutorial_instructions_vertical">Вверх — верно, вниз — пропуск.</string>
     <string name="tutorial_step_swipe_title">Жесты для очков</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="score_change">Score change: %+d</string>
     <string name="turn_timeline_title">Turn timeline</string>
     <string name="timeline_score_breakdown">See how the team built this round\'s score.</string>
+    <string name="timeline_score_graph_label">Score over time</string>
     <string name="timeline_no_events">No words were recorded this turn.</string>
     <string name="timeline_bonus_label">Bonus</string>
     <string name="timeline_change">%1$+d</string>


### PR DESCRIPTION
## Summary
- embed a score-over-time sparkline into the turn result timeline header and add the supporting string copy
- tighten padding, typography, and indicator sizing so timeline rows take up less space while staying legible
- guard deck cover image loading with a local reference to satisfy Kotlin's smart cast rules during compilation

## Testing
- ./gradlew --console=plain spotlessCheck
- ./gradlew --console=plain detekt
- ./gradlew --console=plain :domain:test
- ./gradlew --console=plain :data:test
- ./gradlew --console=plain :app:testDebugUnitTest
- ./gradlew --console=plain :app:assembleDebug

------
https://chatgpt.com/codex/tasks/task_b_68cc05d1f5d4832c8760ca522c9a392c