### PR TITLE
Handle cover image import errors and surface word class summaries

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -176,6 +176,8 @@ import androidx.compose.material.icons.filled.Verified
 import androidx.compose.ui.text.style.TextOverflow
 import com.example.alias.data.db.TurnHistoryEntity
 import com.example.alias.data.db.DifficultyBucket
+import com.example.alias.data.db.WordClassCount
+import com.example.alias.domain.word.WordClassCatalog
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 
@@ -1629,6 +1631,7 @@ private fun DeckCoverArt(deck: DeckEntity, modifier: Modifier = Modifier) {
         deck.name.firstOrNull()?.uppercaseChar()?.toString()
             ?: deck.language.uppercase(Locale.getDefault())
     }
+    val image = coverImage
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -1636,9 +1639,9 @@ private fun DeckCoverArt(deck: DeckEntity, modifier: Modifier = Modifier) {
             .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
             .background(gradient)
     ) {
-        if (coverImage != null) {
+        if (image != null) {
             Image(
-                bitmap = coverImage,
+                bitmap = image,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.matchParentSize()
@@ -1991,6 +1994,7 @@ private fun FilterChipGroup(
 private fun DeckDetailScreen(vm: MainViewModel, deck: DeckEntity) {
     var count by remember { mutableStateOf<Int?>(null) }
     var categories by remember { mutableStateOf<List<String>?>(null) }
+    var wordClassCounts by remember { mutableStateOf<List<WordClassCount>?>(null) }
     var histogram by remember { mutableStateOf<List<DifficultyBucket>>(emptyList()) }
     var histogramLoading by remember { mutableStateOf(true) }
     var recentWords by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -2010,8 +2014,10 @@ private fun DeckDetailScreen(vm: MainViewModel, deck: DeckEntity) {
     }
 
     LaunchedEffect(deck.id) {
+        wordClassCounts = null
         launch { count = vm.getWordCount(deck.id) }
         launch { categories = runCatching { vm.getDeckCategories(deck.id) }.getOrElse { emptyList() } }
+        launch { wordClassCounts = runCatching { vm.getDeckWordClassCounts(deck.id) }.getOrElse { emptyList() } }
         launch {
             histogramLoading = true
             try {
@@ -2081,6 +2087,50 @@ private fun DeckDetailScreen(vm: MainViewModel, deck: DeckEntity) {
                         ) {
                             currentCategories.forEach { category ->
                                 AssistChip(onClick = {}, enabled = false, label = { Text(category) })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        DetailCard(title = stringResource(R.string.word_classes_label)) {
+            when (val counts = wordClassCounts) {
+                null -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+                }
+
+                else -> {
+                    if (counts.isEmpty()) {
+                        Text(stringResource(R.string.deck_word_classes_empty))
+                    } else {
+                        val totalTagged = counts.sumOf { it.count }
+                        Text(
+                            stringResource(
+                                R.string.deck_word_classes_summary,
+                                counts.size,
+                                totalTagged
+                            ),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            counts.forEach { entry ->
+                                val label = when (entry.wordClass) {
+                                    WordClassCatalog.NOUN -> stringResource(R.string.word_class_label_noun)
+                                    WordClassCatalog.VERB -> stringResource(R.string.word_class_label_verb)
+                                    WordClassCatalog.ADJECTIVE -> stringResource(R.string.word_class_label_adj)
+                                    else -> entry.wordClass
+                                }
+                                AssistChip(
+                                    onClick = {},
+                                    enabled = false,
+                                    label = {
+                                        Text(stringResource(R.string.deck_word_classes_chip, label, entry.count))
+                                    }
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -1,18 +1,22 @@
 package com.example.alias
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.net.Uri
+import android.util.Base64
 import android.util.Log
 import androidx.compose.material3.SnackbarDuration
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.alias.data.DeckRepository
-import com.example.alias.data.db.WordDao
 import com.example.alias.data.db.DifficultyBucket
+import com.example.alias.data.db.WordClassCount
+import com.example.alias.data.db.WordDao
 import com.example.alias.data.download.PackDownloader
 import com.example.alias.data.TurnHistoryRepository
 import com.example.alias.data.db.TurnHistoryEntity
 import com.example.alias.data.pack.PackParser
+import com.example.alias.data.pack.ParsedPack
 import com.example.alias.data.settings.Settings
 import com.example.alias.data.settings.SettingsRepository
 import com.example.alias.domain.DefaultGameEngine
@@ -22,6 +26,7 @@ import com.example.alias.domain.word.WordClassCatalog
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
@@ -31,6 +36,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -38,6 +45,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.Locale
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
@@ -117,10 +125,71 @@ class MainViewModel @Inject constructor(
         val settings: Settings,
     )
 
+    private data class WordClassAvailabilityKey(
+        val deckIds: Set<String>,
+        val language: String,
+        val allowNSFW: Boolean,
+    )
+
+    private data class SanitizedPack(
+        val pack: ParsedPack,
+        val coverImageError: Throwable?,
+    )
+
+    private fun canonicalizeWordClassFilters(raw: Collection<String>): List<String> {
+        val normalized = raw
+            .asSequence()
+            .mapNotNull { value ->
+                val trimmed = value.trim()
+                if (trimmed.isEmpty()) {
+                    null
+                } else {
+                    trimmed.uppercase(Locale.ROOT)
+                }
+            }
+            .toList()
+        if (normalized.isEmpty()) return emptyList()
+        val orderedKnown = WordClassCatalog.order(normalized)
+        val knownSet = orderedKnown.toSet()
+        val extras = normalized
+            .asSequence()
+            .filterNot { knownSet.contains(it) }
+            .distinct()
+            .sorted()
+            .toList()
+        return orderedKnown + extras
+    }
+
+    private suspend fun sanitizeCoverImage(pack: ParsedPack): SanitizedPack {
+        val coverError = withContext(Dispatchers.IO) {
+            pack.deck.coverImageBase64?.let { encoded ->
+                try {
+                    val decoded = Base64.decode(encoded, Base64.DEFAULT)
+                    require(decoded.isNotEmpty()) { "Cover image is empty" }
+                    val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                    BitmapFactory.decodeByteArray(decoded, 0, decoded.size, opts)
+                    require(opts.outWidth > 0 && opts.outHeight > 0) { "Cover image has invalid dimensions" }
+                    null
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (t: Throwable) {
+                    Log.e(TAG, "Failed to decode deck cover image for ${pack.deck.id}", t)
+                    t
+                }
+            }
+        }
+        val sanitized = if (coverError != null) {
+            pack.copy(deck = pack.deck.copy(coverImageBase64 = null))
+        } else {
+            pack
+        }
+        return SanitizedPack(sanitized, coverError)
+    }
+
     private fun Settings.toWordQueryFilters(deckIdsOverride: Set<String>? = null): WordQueryFilters {
         val deckIds = (deckIdsOverride ?: enabledDeckIds).toList()
         val categories = selectedCategories.toList()
-        val classes = WordClassCatalog.order(selectedWordClasses)
+        val classes = canonicalizeWordClassFilters(selectedWordClasses)
         return WordQueryFilters(
             deckIds = deckIds,
             language = languagePreference,
@@ -184,9 +253,16 @@ class MainViewModel @Inject constructor(
                     toImport.addAll(assetFiles)
                 }
                 for (f in toImport) {
-                    runCatching {
+                    try {
                         val content = context.assets.open("decks/$f").bufferedReader().use { it.readText() }
-                        deckRepository.importJson(content)
+                        val pack = PackParser.fromJson(content)
+                        val (sanitizedPack, coverError) = sanitizeCoverImage(pack)
+                        deckRepository.importPack(sanitizedPack)
+                        if (coverError != null) {
+                            Log.w(TAG, "Bundled deck $f cover art discarded due to decode failure", coverError)
+                        }
+                    } catch (t: Throwable) {
+                        Log.e(TAG, "Failed to import bundled deck $f", t)
                     }
                 }
                 // Persist current checksums if any
@@ -250,7 +326,7 @@ class MainViewModel @Inject constructor(
                         }
                         _wordInfo.value = map
                         _availableCategories.value = categories
-                        _availableWordClasses.value = WordClassCatalog.order(classes)
+                        _availableWordClasses.value = canonicalizeWordClassFilters(classes)
                     }
                 }
             }
@@ -264,6 +340,29 @@ class MainViewModel @Inject constructor(
             )
             val seed = java.security.SecureRandom().nextLong()
             e.startMatch(config, teams = initial.settings.teams, seed = seed)
+        }
+
+        viewModelScope.launch {
+            settingsRepository.settings
+                .map { settings ->
+                    WordClassAvailabilityKey(
+                        deckIds = settings.enabledDeckIds,
+                        language = settings.languagePreference,
+                        allowNSFW = settings.allowNSFW,
+                    )
+                }
+                .distinctUntilChanged()
+                .collectLatest { key ->
+                    val ids = key.deckIds.toList()
+                    val classes = if (ids.isEmpty()) {
+                        emptyList()
+                    } else {
+                        withContext(Dispatchers.IO) {
+                            wordDao.getAvailableWordClasses(ids, key.language, key.allowNSFW)
+                        }
+                    }
+                    _availableWordClasses.value = canonicalizeWordClassFilters(classes)
+                }
         }
     }
 
@@ -356,6 +455,22 @@ class MainViewModel @Inject constructor(
     suspend fun getDeckRecentWords(deckId: String, limit: Int = 8): List<String> =
         withContext(Dispatchers.IO) { deckRepository.getRecentWords(deckId, limit) }
 
+    suspend fun getDeckWordClassCounts(deckId: String): List<WordClassCount> =
+        withContext(Dispatchers.IO) {
+            val counts = wordDao.getWordClassCounts(deckId)
+            val orderedKeys = WordClassCatalog.order(counts.map { it.wordClass })
+            val byClass = counts.associateBy { it.wordClass }
+            buildList {
+                orderedKeys.forEach { key ->
+                    byClass[key]?.let { add(it) }
+                }
+                val orderedSet = orderedKeys.toSet()
+                counts.filter { it.wordClass !in orderedSet }
+                    .sortedBy { it.wordClass }
+                    .forEach { add(it) }
+            }
+        }
+
     fun updateSeenTutorial(value: Boolean) {
         viewModelScope.launch { settingsRepository.updateSeenTutorial(value) }
     }
@@ -391,7 +506,9 @@ class MainViewModel @Inject constructor(
                 // Try JSON first
                 val text = bytes.toString(Charsets.UTF_8)
                 _deckDownloadProgress.value = DeckDownloadProgress(step = DeckDownloadStep.IMPORTING)
-                withContext(Dispatchers.IO) { deckRepository.importJson(text) }
+                val parsed = withContext(Dispatchers.IO) { PackParser.fromJson(text) }
+                val (sanitizedPack, imageError) = sanitizeCoverImage(parsed)
+                withContext(Dispatchers.IO) { deckRepository.importPack(sanitizedPack) }
                 _uiEvents.tryEmit(
                     UiEvent(
                         message = "Imported deck from URL",
@@ -400,6 +517,16 @@ class MainViewModel @Inject constructor(
                         dismissCurrent = true
                     )
                 )
+                if (imageError != null) {
+                    _uiEvents.tryEmit(
+                        UiEvent(
+                            message = "Deck cover image couldn't be processed",
+                            actionLabel = "Dismiss",
+                            duration = SnackbarDuration.Long,
+                            isError = true,
+                        )
+                    )
+                }
             } catch (t: Throwable) {
                 _uiEvents.tryEmit(
                     UiEvent(
@@ -424,17 +551,28 @@ class MainViewModel @Inject constructor(
                         ?: throw IllegalStateException("Empty file")
                 }
                 val pack = withContext(Dispatchers.IO) { PackParser.fromJson(text) }
-                withContext(Dispatchers.IO) { deckRepository.importPack(pack) }
+                val (sanitizedPack, imageError) = sanitizeCoverImage(pack)
+                withContext(Dispatchers.IO) { deckRepository.importPack(sanitizedPack) }
                 runCatching {
                     val s = settingsRepository.settings.first()
-                    if (pack.deck.language == s.languagePreference) {
+                    if (sanitizedPack.deck.language == s.languagePreference) {
                         val ids = s.enabledDeckIds.toMutableSet()
-                        if (ids.add(pack.deck.id)) {
+                        if (ids.add(sanitizedPack.deck.id)) {
                             settingsRepository.setEnabledDeckIds(ids)
                         }
                     }
                 }
                 _uiEvents.tryEmit(UiEvent(message = "Imported deck", actionLabel = "OK", duration = SnackbarDuration.Short))
+                if (imageError != null) {
+                    _uiEvents.tryEmit(
+                        UiEvent(
+                            message = "Deck cover image couldn't be processed",
+                            actionLabel = "Dismiss",
+                            duration = SnackbarDuration.Long,
+                            isError = true,
+                        )
+                    )
+                }
             } catch (t: Throwable) {
                 _uiEvents.tryEmit(
                     UiEvent(
@@ -572,7 +710,7 @@ class MainViewModel @Inject constructor(
                 val list = if (filters.deckIds.isEmpty()) emptyList() else wordDao.getAvailableWordClasses(
                     filters.deckIds, filters.language, filters.allowNSFW
                 )
-                _availableWordClasses.value = WordClassCatalog.order(list)
+                _availableWordClasses.value = canonicalizeWordClassFilters(list)
             }
             val e = DefaultGameEngine(words, viewModelScope)
             _engine.value = e

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -87,6 +87,12 @@
     <string name="deck_downloaded_unknown">Загружено: нет данных</string>
     <string name="deck_categories_title">Категории</string>
     <string name="deck_categories_empty">Категории отсутствуют</string>
+    <string name="deck_word_classes_empty">Классы слов отсутствуют.</string>
+    <string name="deck_word_classes_summary">Классы слов: %1$d, помечено %2$d слов</string>
+    <string name="deck_word_classes_chip">%1$s · %2$d</string>
+    <string name="word_class_label_adj">Прилагательные</string>
+    <string name="word_class_label_verb">Глаголы</string>
+    <string name="word_class_label_noun">Существительные</string>
     <string name="deck_examples_title">Примеры слов</string>
     <string name="deck_examples_loading">Загрузка примеров…</string>
     <string name="deck_examples_error">Не удалось загрузить примеры.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,12 @@
     <string name="deck_downloaded_unknown">Downloaded: Not available</string>
     <string name="deck_categories_title">Categories</string>
     <string name="deck_categories_empty">No categories</string>
+    <string name="deck_word_classes_empty">No word classes tagged.</string>
+    <string name="deck_word_classes_summary">%1$d classes covering %2$d words</string>
+    <string name="deck_word_classes_chip">%1$s · %2$d</string>
+    <string name="word_class_label_adj">Adjectives</string>
+    <string name="word_class_label_verb">Verbs</string>
+    <string name="word_class_label_noun">Nouns</string>
     <string name="deck_examples_title">Word examples</string>
     <string name="deck_examples_loading">Loading examples…</string>
     <string name="deck_examples_error">Unable to load examples.</string>

--- a/data/src/main/java/com/example/alias/data/db/WordDao.kt
+++ b/data/src/main/java/com/example/alias/data/db/WordDao.kt
@@ -100,6 +100,13 @@ interface WordDao {
     ): List<String>
 
     @Query(
+        "SELECT UPPER(wordClass) AS wordClass, COUNT(*) AS count FROM word_classes " +
+            "WHERE deckId = :deckId " +
+            "GROUP BY UPPER(wordClass)"
+    )
+    suspend fun getWordClassCounts(deckId: String): List<WordClassCount>
+
+    @Query(
         "SELECT DISTINCT category FROM words " +
             "WHERE deckId = :deckId " +
             "AND category IS NOT NULL AND TRIM(category) != '' " +
@@ -143,5 +150,10 @@ data class WordBrief(
 /** Aggregated difficulty bucket for deck analytics. */
 data class DifficultyBucket(
     val difficulty: Int,
+    val count: Int,
+)
+
+data class WordClassCount(
+    val wordClass: String,
     val count: Int,
 )

--- a/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
+++ b/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
@@ -7,12 +7,25 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
-import com.example.alias.domain.word.WordClassCatalog
+import java.util.Locale
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 private val DEFAULT_TEAMS = listOf("Red", "Blue")
+
+private fun normalizeWordClasses(values: Set<String>): Set<String> {
+    return values
+        .mapNotNull { value ->
+            val trimmed = value.trim()
+            if (trimmed.isEmpty()) {
+                null
+            } else {
+                trimmed.uppercase(Locale.ROOT)
+            }
+        }
+        .toSet()
+}
 
 /**
  * Local settings persisted via Preferences DataStore.
@@ -106,9 +119,7 @@ class SettingsRepositoryImpl(
             maxDifficulty = p[Keys.MAX_DIFFICULTY] ?: 5,
             verticalSwipes = p[Keys.VERTICAL_SWIPES] ?: false,
             selectedCategories = p[Keys.CATEGORIES_FILTER] ?: emptySet(),
-            selectedWordClasses = WordClassCatalog.filterAllowed(
-                p[Keys.WORD_CLASSES_FILTER] ?: emptySet()
-            ).toSet(),
+            selectedWordClasses = normalizeWordClasses(p[Keys.WORD_CLASSES_FILTER] ?: emptySet()),
             orientation = p[Keys.ORIENTATION] ?: "system",
             trustedSources = p[Keys.TRUSTED_SOURCES] ?: emptySet(),
             seenTutorial = p[Keys.SEEN_TUTORIAL] ?: false,
@@ -192,7 +203,7 @@ class SettingsRepositoryImpl(
     }
 
     override suspend fun setWordClassesFilter(classes: Set<String>) {
-        val normalized = WordClassCatalog.filterAllowed(classes).toSet()
+        val normalized = normalizeWordClasses(classes)
         dataStore.edit { it[Keys.WORD_CLASSES_FILTER] = normalized }
     }
 

--- a/data/src/test/java/com/example/alias/data/DeckRepositoryTest.kt
+++ b/data/src/test/java/com/example/alias/data/DeckRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.example.alias.data
 import com.example.alias.data.db.DeckDao
 import com.example.alias.data.db.DeckEntity
 import com.example.alias.data.db.WordClassEntity
+import com.example.alias.data.db.WordClassCount
 import com.example.alias.data.db.WordDao
 import com.example.alias.data.db.WordBrief
 import com.example.alias.data.db.WordEntity
@@ -298,6 +299,16 @@ class DeckRepositoryTest {
                 .filter { (it.deckId to it.wordText) in relevantWords }
                 .map { it.wordClass.uppercase() }
                 .distinct()
+        }
+
+        override suspend fun getWordClassCounts(deckId: String): List<WordClassCount> {
+            return wordClassEntries
+                .filter { it.deckId == deckId }
+                .groupBy { it.wordClass.uppercase() }
+                .map { (wordClass, entries) ->
+                    WordClassCount(wordClass = wordClass, count = entries.size)
+                }
+                .sortedBy { it.wordClass }
         }
 
         override suspend fun getDeckCategories(deckId: String): List<String> {


### PR DESCRIPTION
## Summary
- validate imported deck cover images before persisting, drop invalid artwork, and surface a snackbar when decoding fails
- keep word-class filter options in sync with the current enabled decks
- show localized word-class count summaries on the deck detail screen

## Testing
- ./gradlew spotlessCheck detekt :domain:test :data:test :app:testDebugUnitTest :app:assembleDebug


------
https://chatgpt.com/codex/tasks/task_b_68cc054dcef0832cb5c7c6ccde287342