### PR TITLE
Improve turn summary header UI

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -66,7 +66,36 @@
     <string name="end_match">Завершить матч</string>
     <string name="next_team">Следующая команда</string>
     <string name="turn_summary">Ход: %s</string>
+    <string name="turn_summary_status_match_complete">Матч завершён! Итоговый счёт ниже.</string>
+    <string name="turn_summary_status_next_team">Готовьтесь к следующей команде.</string>
     <string name="score_change">Изменение счёта: %+d</string>
+    <plurals name="turn_summary_stat_correct">
+        <item quantity="one">%d верное слово</item>
+        <item quantity="few">%d верных слова</item>
+        <item quantity="many">%d верных слов</item>
+        <item quantity="other">%d верных слова</item>
+    </plurals>
+    <plurals name="turn_summary_stat_skipped">
+        <item quantity="one">%d пропуск</item>
+        <item quantity="few">%d пропуска</item>
+        <item quantity="many">%d пропусков</item>
+        <item quantity="other">%d пропуска</item>
+    </plurals>
+    <plurals name="turn_summary_stat_pending">
+        <item quantity="one">%d требует проверки</item>
+        <item quantity="few">%d требуют проверки</item>
+        <item quantity="many">%d требуют проверки</item>
+        <item quantity="other">%d требуют проверки</item>
+    </plurals>
+    <plurals name="turn_summary_stat_bonus">
+        <item quantity="one">%d бонусная серия</item>
+        <item quantity="few">%d бонусные серии</item>
+        <item quantity="many">%d бонусных серий</item>
+        <item quantity="other">%d бонусные серии</item>
+    </plurals>
+    <string name="turn_summary_stat_time_label">Затраченное время</string>
+    <string name="turn_summary_stat_time_value">%1$.1f с</string>
+    <string name="turn_summary_stat_time_under_second_value">&lt;1 с</string>
     <string name="turn_timeline_title">Хронология хода</string>
     <string name="timeline_score_breakdown">Посмотрите, как команда набрала очки в этом раунде.</string>
     <string name="timeline_score_graph_label">Очки по времени</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,7 +60,28 @@
     <string name="end_match">End Match</string>
     <string name="next_team">Next Team</string>
     <string name="turn_summary">Turn summary for %s</string>
+    <string name="turn_summary_status_match_complete">Match complete! Final scores below.</string>
+    <string name="turn_summary_status_next_team">Get ready for the next team.</string>
     <string name="score_change">Score change: %+d</string>
+    <plurals name="turn_summary_stat_correct">
+        <item quantity="one">%d correct word</item>
+        <item quantity="other">%d correct words</item>
+    </plurals>
+    <plurals name="turn_summary_stat_skipped">
+        <item quantity="one">%d skipped</item>
+        <item quantity="other">%d skipped</item>
+    </plurals>
+    <plurals name="turn_summary_stat_pending">
+        <item quantity="one">%d needs review</item>
+        <item quantity="other">%d need review</item>
+    </plurals>
+    <plurals name="turn_summary_stat_bonus">
+        <item quantity="one">%d bonus streak</item>
+        <item quantity="other">%d bonus streaks</item>
+    </plurals>
+    <string name="turn_summary_stat_time_label">Time used</string>
+    <string name="turn_summary_stat_time_value">%1$.1fs</string>
+    <string name="turn_summary_stat_time_under_second_value">&lt;1s</string>
     <string name="turn_timeline_title">Turn timeline</string>
     <string name="timeline_score_breakdown">See how the team built this round\'s score.</string>
     <string name="timeline_score_graph_label">Score over time</string>


### PR DESCRIPTION
## Summary
- add a gradient hero card to the turn summary screen with prominent status text and score delta
- surface per-turn stats as colorful chips by summarising outcomes (correct, skips, bonuses, time)
- localize the new summary messaging for English and Russian

## Testing
- ./gradlew spotlessCheck *(fails: ktlint max-line-length in data/src/test/java/com/example/alias/data/pack/PackParserTest.kt and property-naming in app/src/main/java/com/example/alias/MainViewModel.kt)*

------
https://chatgpt.com/codex/tasks/task_b_68cd49a88764832cb2131128babb0b96