### PR TITLE
[domain] End match when words exhausted

### DIFF
--- a/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
+++ b/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
@@ -122,7 +122,9 @@ class DefaultGameEngine(
                 if (correct) correctTotal++ else correctTotal--
             }
             outcomes[index] = item.copy(correct = correct, skipped = !correct)
-            val nowMatchOver = correctTotal >= config.targetWords
+            val noWordsLeft = queue.isEmpty()
+            val nowMatchOver = correctTotal >= config.targetWords || noWordsLeft
+            matchOver = nowMatchOver
             _state.update { GameState.TurnFinished(team, turnScore, scores.toMap(), outcomes.toList(), nowMatchOver) }
         }
     }

--- a/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
+++ b/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
@@ -177,7 +177,7 @@ class DefaultGameEngine(
                 outcomes.add(TurnOutcome(currentWord, false, System.currentTimeMillis(), skipped = false))
             }
         }
-        matchOver = reachedTarget || (byTimer && noWordsLeft)
+        matchOver = reachedTarget || noWordsLeft
         // Always end the turn first; if matchOver, UI can finalize via nextTurn()
         _state.update { GameState.TurnFinished(team, turnScore, scores.toMap(), outcomes.toList(), matchOver) }
     }

--- a/domain/src/test/kotlin/com/example/alias/domain/DefaultGameEngineTest.kt
+++ b/domain/src/test/kotlin/com/example/alias/domain/DefaultGameEngineTest.kt
@@ -202,12 +202,31 @@ class DefaultGameEngineTest {
             assertEquals(2, finished.outcomes.size)
             assertTrue(finished.outcomes[0].correct)
             assertFalse(finished.outcomes[1].correct)
-            assertFalse(finished.matchOver)
+            assertTrue(finished.matchOver)
 
             engine.overrideOutcome(1, true)
             val updated = assertIs<GameState.TurnFinished>(engine.state.value)
             assertEquals(2, updated.deltaScore)
             assertTrue(updated.outcomes[1].correct)
             assertEquals(2, updated.scores["Team"])
+        }
+
+    @Test
+    fun `match finishes when queue empties before reaching target`() =
+        runTest {
+            val words = listOf("apple", "banana")
+            val engine = DefaultGameEngine(words, this)
+            val cfg = config.copy(targetWords = 3, roundSeconds = 10)
+            engine.startMatch(cfg, teams = listOf("Solo"), seed = 0L)
+
+            engine.startTurn()
+            engine.correct()
+            engine.correct()
+
+            val finished = assertIs<GameState.TurnFinished>(engine.state.value)
+            assertTrue(finished.matchOver)
+
+            engine.nextTurn()
+            assertIs<GameState.MatchFinished>(engine.state.value)
         }
 }

--- a/domain/src/test/kotlin/com/example/alias/domain/DefaultGameEngineTest.kt
+++ b/domain/src/test/kotlin/com/example/alias/domain/DefaultGameEngineTest.kt
@@ -131,7 +131,7 @@ class DefaultGameEngineTest {
             // Change should be -(1+2) = -3; total delta becomes -2
             assertEquals(-2, updated.deltaScore)
             assertEquals(-2, updated.scores["t"]) // team total
-            assertFalse(updated.matchOver)
+            assertTrue(updated.matchOver)
         }
 
     @Test
@@ -225,6 +225,10 @@ class DefaultGameEngineTest {
 
             val finished = assertIs<GameState.TurnFinished>(engine.state.value)
             assertTrue(finished.matchOver)
+
+            engine.overrideOutcome(0, false)
+            val updated = assertIs<GameState.TurnFinished>(engine.state.value)
+            assertTrue(updated.matchOver)
 
             engine.nextTurn()
             assertIs<GameState.MatchFinished>(engine.state.value)


### PR DESCRIPTION
## Summary
- treat an empty word queue as a match ending condition and keep TurnFinished.matchOver consistent
- add coverage ensuring matches finish when the word queue empties before hitting the target

## Testing
- ./gradlew :domain:test --console=plain

------
https://chatgpt.com/codex/tasks/task_b_68cd50ed60e8832c9fd3f31edd214536