### PR TITLE
Adjust WordCard height based on layout constraints

### DIFF
--- a/app/src/main/java/com/example/alias/ui/TutorialOverlay.kt
+++ b/app/src/main/java/com/example/alias/ui/TutorialOverlay.kt
@@ -62,6 +62,7 @@ import kotlin.math.roundToInt
 fun TutorialOverlay(
     verticalMode: Boolean,
     onDismiss: () -> Unit,
+    cardBounds: Rect? = null,
     modifier: Modifier = Modifier,
 ) {
     val swipeBody = if (verticalMode) {
@@ -97,7 +98,7 @@ fun TutorialOverlay(
     ) {
         BoxWithConstraints(Modifier.fillMaxSize()) {
             val containerSize = Size(constraints.maxWidth.toFloat(), constraints.maxHeight.toFloat())
-            val focusRect = step.focus.calculateRect(containerSize)
+            val focusRect = step.focus.calculateRect(containerSize, cardBounds)
             val density = LocalDensity.current
             val scrimColor = MaterialTheme.colorScheme.scrim.copy(alpha = 0.75f)
             Box(
@@ -248,18 +249,28 @@ private data class TutorialStep(
 )
 
 private sealed interface TutorialFocus {
-    fun calculateRect(containerSize: Size): Rect
+    fun calculateRect(containerSize: Size, cardBounds: Rect?): Rect
 
     object Card : TutorialFocus {
-        override fun calculateRect(containerSize: Size): Rect = containerSize.rectangle(
-            widthFraction = 0.78f,
-            heightFraction = 0.38f,
-            topFraction = 0.26f
-        )
+        override fun calculateRect(containerSize: Size, cardBounds: Rect?): Rect {
+            val measuredRect = cardBounds?.let { rect ->
+                val left = rect.left.coerceIn(0f, containerSize.width)
+                val top = rect.top.coerceIn(0f, containerSize.height)
+                val right = rect.right.coerceIn(left, containerSize.width)
+                val bottom = rect.bottom.coerceIn(top, containerSize.height)
+                Rect(left, top, right, bottom)
+            }
+            return measuredRect ?: containerSize.rectangle(
+                widthFraction = 0.78f,
+                heightFraction = 0.38f,
+                topFraction = 0.26f
+            )
+        }
     }
 
     object Status : TutorialFocus {
-        override fun calculateRect(containerSize: Size): Rect = containerSize.rectangle(
+        @Suppress("UNUSED_PARAMETER")
+        override fun calculateRect(containerSize: Size, cardBounds: Rect?): Rect = containerSize.rectangle(
             widthFraction = 0.9f,
             heightFraction = 0.2f,
             topFraction = 0.08f
@@ -267,7 +278,8 @@ private sealed interface TutorialFocus {
     }
 
     object Controls : TutorialFocus {
-        override fun calculateRect(containerSize: Size): Rect = containerSize.rectangle(
+        @Suppress("UNUSED_PARAMETER")
+        override fun calculateRect(containerSize: Size, cardBounds: Rect?): Rect = containerSize.rectangle(
             widthFraction = 0.9f,
             heightFraction = 0.22f,
             topFraction = 0.68f

--- a/app/src/main/java/com/example/alias/ui/WordCard.kt
+++ b/app/src/main/java/com/example/alias/ui/WordCard.kt
@@ -9,8 +9,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -115,7 +115,6 @@ fun WordCard(
         modifier = modifier
             .then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
             .fillMaxWidth()
-            .height(200.dp)
             .offset { IntOffset(currentX.roundToInt(), currentY.roundToInt()) }
             .graphicsLayer(rotationZ = if (verticalMode) 0f else currentX / ROTATION_DIVISOR)
             .scale(scale)
@@ -202,9 +201,7 @@ fun WordCard(
         shadowElevation = 10.dp
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(200.dp),
+            modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
             Text(

--- a/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -64,6 +65,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 private val LARGE_BUTTON_HEIGHT = 80.dp
+private const val CARD_ASPECT_RATIO = 1.8f
 private const val PRE_TURN_COUNTDOWN_SECONDS = 3
 private val TIMER_SAFE_COLOR = Color(0xFF4CAF50)
 private val TIMER_WARNING_COLOR = Color(0xFFFFC107)
@@ -215,7 +217,11 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
                 val nextWord = frozenNext ?: computedNext
                 val nextMeta = nextWord?.let { infoMap[it] }
                 val currentMeta = infoMap[s.word]
-                Box(Modifier.fillMaxWidth().height(200.dp)) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(CARD_ASPECT_RATIO)
+                ) {
                     if (nextWord != null) {
                         WordCard(
                             word = nextWord,
@@ -238,7 +244,9 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
                     }
                     WordCard(
                         word = s.word,
-                        modifier = Modifier.fillMaxSize().zIndex(1f),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .zIndex(1f),
                         enabled = true,
                         vibrator = vibrator,
                         hapticsEnabled = settings.hapticsEnabled,

--- a/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
@@ -39,8 +39,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
@@ -93,6 +96,7 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
     val scope = rememberCoroutineScope()
     val showTutorialOnFirstTurn by vm.showTutorialOnFirstTurn.collectAsState()
     val seenTutorial = settings.seenTutorial
+    var cardBounds by remember { mutableStateOf<Rect?>(null) }
 
     LaunchedEffect(state) {
         if (showTutorialOnFirstTurn && state is GameState.TurnActive && !seenTutorial) {
@@ -100,6 +104,9 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
         } else if (showTutorialOnFirstTurn) {
             // Tutorial was dismissed or not first turn
             vm.dismissTutorialOnFirstTurn()
+        }
+        if (state !is GameState.TurnActive) {
+            cardBounds = null
         }
     }
 
@@ -109,6 +116,7 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
             onDismiss = {
                 vm.updateSeenTutorial(true)
             },
+            cardBounds = cardBounds,
             modifier = Modifier.zIndex(1f)
         )
     }
@@ -221,6 +229,9 @@ fun GameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(CARD_ASPECT_RATIO)
+                        .onGloballyPositioned { coordinates ->
+                            cardBounds = coordinates.boundsInRoot()
+                        }
                 ) {
                     if (nextWord != null) {
                         WordCard(


### PR DESCRIPTION
## Summary
- derive the in-game card stack height from the layout width via a shared aspect ratio
- allow WordCard to fill the space provided by its parent instead of enforcing a 200dp box, keeping overlays and metadata intact

## Testing
- `./gradlew --console=plain :app:testDebugUnitTest`
- `./gradlew --console=plain spotlessCheck` *(fails: pre-existing ktlint violations in app/src/main/java/com/example/alias/Theme.kt and data module)*

------
https://chatgpt.com/codex/tasks/task_b_68cd510c0328832cb3051ff909498b26