### PR TITLE
Avoid crashing game screen when engine is unavailable

### DIFF
--- a/app/src/main/java/com/example/alias/navigation/AliasNavHost.kt
+++ b/app/src/main/java/com/example/alias/navigation/AliasNavHost.kt
@@ -3,9 +3,9 @@ package com.example.alias.navigation
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -83,10 +83,16 @@ fun aliasNavHost(
                 engine?.let { gameEngine ->
                     gameScreen(viewModel, gameEngine, currentSettings)
                 } ?: Surface(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
-                ) {}
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
             }
         }
         composable("decks") {

--- a/app/src/main/java/com/example/alias/navigation/AliasNavHost.kt
+++ b/app/src/main/java/com/example/alias/navigation/AliasNavHost.kt
@@ -80,15 +80,13 @@ fun aliasNavHost(
             val engine by viewModel.engine.collectAsState()
             val currentSettings by viewModel.settings.collectAsState()
             appScaffold(snackbarHostState = snackbarHostState) {
-                if (engine == null) {
-                    Surface(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.surfaceVariant),
-                    ) {}
-                } else {
-                    gameScreen(viewModel, engine!!, currentSettings)
-                }
+                engine?.let { gameEngine ->
+                    gameScreen(viewModel, gameEngine, currentSettings)
+                } ?: Surface(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                ) {}
             }
         }
         composable("decks") {


### PR DESCRIPTION
## Summary
- guard the game destination against a missing engine by using a safe let block
- keep the existing loading surface as a fallback when the engine has not loaded

## Testing
- ./gradlew spotlessCheck --console=plain --no-daemon --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_b_68cd80f87240832c9971cb0c4cfc2b9a