### PR TITLE
Remove verbose overrideOutcome println logging

### DIFF
--- a/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
+++ b/domain/src/main/kotlin/com/example/alias/domain/DefaultGameEngine.kt
@@ -115,9 +115,6 @@ class DefaultGameEngine(
                 } else {
                     -(1 + config.penaltyPerSkip)
                 }
-            println(
-                "DEBUG: overrideOutcome - before: turnScore=$turnScore, correctTotal=$correctTotal, matchOver=$matchOver, item.correct=${item.correct}, skipped=${item.skipped}, change=$change",
-            )
             turnScore += change
             scores[team] = scores.getOrDefault(team, 0) + change
             // Update total correct words across the match based on override
@@ -133,9 +130,6 @@ class DefaultGameEngine(
                 current.matchOver && !reachedTargetBeforeOverride && queue.isEmpty()
             matchOver = nowMatchOver || preserveExistingCompletion
             _state.update { GameState.TurnFinished(team, turnScore, scores.toMap(), outcomes.toList(), matchOver) }
-            println(
-                "DEBUG: overrideOutcome - after: turnScore=$turnScore, correctTotal=$correctTotal, matchOver=$matchOver, nowMatchOver=$nowMatchOver, preserveExistingCompletion=$preserveExistingCompletion, noWordsLeft=$noWordsLeft",
-            )
         }
     }
 


### PR DESCRIPTION
## Summary
- remove direct println debug statements from DefaultGameEngine.overrideOutcome to avoid overly long debug lines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd80faa7a4832cb31686f4be5ed6a4