### PR TITLE
Adjust snackbar color formatting

### DIFF
--- a/app/src/main/java/com/example/alias/ui/AppScaffold.kt
+++ b/app/src/main/java/com/example/alias/ui/AppScaffold.kt
@@ -21,19 +21,10 @@ fun appScaffold(
             snackbarHostState?.let { state ->
                 SnackbarHost(hostState = state) { data ->
                     val msg = data.visuals.message
-                    val isError =
-                        msg.startsWith("Failed", ignoreCase = true) ||
-                            msg.contains("error", ignoreCase = true)
-                    val container = if (isError) {
-                        MaterialTheme.colorScheme.errorContainer
-                    } else {
-                        SnackbarDefaults.color
-                    }
-                    val content = if (isError) {
-                        MaterialTheme.colorScheme.onErrorContainer
-                    } else {
-                        SnackbarDefaults.contentColor
-                    }
+                    val isError = msg.isErrorSnackbarMessage()
+                    val colorScheme = MaterialTheme.colorScheme
+                    val container = if (isError) colorScheme.errorContainer else SnackbarDefaults.color
+                    val content = if (isError) colorScheme.onErrorContainer else SnackbarDefaults.contentColor
                     Snackbar(snackbarData = data, containerColor = container, contentColor = content)
                 }
             }
@@ -42,3 +33,6 @@ fun appScaffold(
         Box(Modifier.padding(scaffoldPadding)) { content() }
     }
 }
+
+private fun String.isErrorSnackbarMessage(): Boolean =
+    startsWith("Failed", ignoreCase = true) || contains("error", ignoreCase = true)

--- a/app/src/main/java/com/example/alias/ui/AppScaffold.kt
+++ b/app/src/main/java/com/example/alias/ui/AppScaffold.kt
@@ -21,9 +21,19 @@ fun appScaffold(
             snackbarHostState?.let { state ->
                 SnackbarHost(hostState = state) { data ->
                     val msg = data.visuals.message
-                    val isError = msg.startsWith("Failed", ignoreCase = true) || msg.contains("error", ignoreCase = true)
-                    val container = if (isError) MaterialTheme.colorScheme.errorContainer else SnackbarDefaults.color
-                    val content = if (isError) MaterialTheme.colorScheme.onErrorContainer else SnackbarDefaults.contentColor
+                    val isError =
+                        msg.startsWith("Failed", ignoreCase = true) ||
+                            msg.contains("error", ignoreCase = true)
+                    val container = if (isError) {
+                        MaterialTheme.colorScheme.errorContainer
+                    } else {
+                        SnackbarDefaults.color
+                    }
+                    val content = if (isError) {
+                        MaterialTheme.colorScheme.onErrorContainer
+                    } else {
+                        SnackbarDefaults.contentColor
+                    }
                     Snackbar(snackbarData = data, containerColor = container, contentColor = content)
                 }
             }


### PR DESCRIPTION
## Summary
- reformat the snackbar error detection and color assignments to keep each line under the 120 character limit

## Testing
- `./gradlew spotlessCheck detekt :domain:test :data:test :app:testDebugUnitTest :app:assembleDebug --console=plain` *(fails: existing detekt and buildConfig issues)*

------
https://chatgpt.com/codex/tasks/task_b_68cd80fb72ac832c989b02b1cddd906f