### PR TITLE
Refactor home screen state and actions

### DIFF
--- a/app/src/main/java/com/example/alias/navigation/AliasNavHost.kt
+++ b/app/src/main/java/com/example/alias/navigation/AliasNavHost.kt
@@ -31,6 +31,8 @@ import com.example.alias.ui.decks.deckDetailScreen
 import com.example.alias.ui.decks.decksScreen
 import com.example.alias.ui.game.gameScreen
 import com.example.alias.ui.historyScreen
+import com.example.alias.ui.home.HomeActions
+import com.example.alias.ui.home.HomeViewState
 import com.example.alias.ui.home.homeScreen
 import com.example.alias.ui.settings.settingsScreen
 
@@ -61,18 +63,22 @@ fun aliasNavHost(
             val recentHistory by recentHistoryFlow.collectAsState(initial = emptyList())
             appScaffold(snackbarHostState = snackbarHostState) {
                 homeScreen(
-                    gameState = gameState,
-                    settings = settings,
-                    decks = decks,
-                    recentHistory = recentHistory,
-                    onResumeMatch = { navController.navigate("game") },
-                    onStartNewMatch = {
-                        viewModel.restartMatch()
-                        navController.navigate("game")
-                    },
-                    onDecks = { navController.navigate("decks") },
-                    onSettings = { navController.navigate("settings") },
-                    onHistory = { navController.navigate("history") },
+                    state = HomeViewState(
+                        gameState = gameState,
+                        settings = settings,
+                        decks = decks,
+                        recentHistory = recentHistory,
+                    ),
+                    actions = HomeActions(
+                        onResumeMatch = { navController.navigate("game") },
+                        onStartNewMatch = {
+                            viewModel.restartMatch()
+                            navController.navigate("game")
+                        },
+                        onDecks = { navController.navigate("decks") },
+                        onSettings = { navController.navigate("settings") },
+                        onHistory = { navController.navigate("history") },
+                    ),
                 )
             }
         }


### PR DESCRIPTION
## Summary
- bundle the Home screen inputs into new `HomeViewState` and `HomeActions` containers
- update the screen implementation to consume the new view state and actions objects
- adjust the navigation host to construct the containers when rendering the Home destination

## Testing
- `./gradlew spotlessCheck --console=plain`
- `./gradlew detekt --console=plain`
- `./gradlew :domain:test --console=plain --no-build-cache -Dkotlin.incremental=false`
- `./gradlew :data:test --console=plain --no-build-cache -Dkotlin.incremental=false`
- `./gradlew :app:testDebugUnitTest --console=plain --no-build-cache -Dkotlin.incremental=false`
- `./gradlew :app:assembleDebug --console=plain --no-build-cache -Dkotlin.incremental=false`


------
https://chatgpt.com/codex/tasks/task_b_68cd80fc5ea0832cb0542981e8d1609d