### PR TITLE
Refactor settings update to use request object

### DIFF
--- a/app/src/main/java/com/example/alias/SettingsUpdateRequest.kt
+++ b/app/src/main/java/com/example/alias/SettingsUpdateRequest.kt
@@ -1,0 +1,43 @@
+package com.example.alias
+
+import com.example.alias.data.settings.Settings
+
+/**
+ * Data transfer object bundling all inputs required to persist the settings update.
+ */
+data class SettingsUpdateRequest(
+    val roundSeconds: Int,
+    val targetWords: Int,
+    val maxSkips: Int,
+    val penaltyPerSkip: Int,
+    val punishSkips: Boolean,
+    val language: String,
+    val uiLanguage: String,
+    val allowNSFW: Boolean,
+    val haptics: Boolean,
+    val sound: Boolean,
+    val oneHanded: Boolean,
+    val verticalSwipes: Boolean,
+    val orientation: String,
+    val teams: List<String>,
+) {
+    companion object {
+        fun from(settings: Settings): SettingsUpdateRequest =
+            SettingsUpdateRequest(
+                roundSeconds = settings.roundSeconds,
+                targetWords = settings.targetWords,
+                maxSkips = settings.maxSkips,
+                penaltyPerSkip = settings.penaltyPerSkip,
+                punishSkips = settings.punishSkips,
+                language = settings.languagePreference,
+                uiLanguage = settings.uiLanguage,
+                allowNSFW = settings.allowNSFW,
+                haptics = settings.hapticsEnabled,
+                sound = settings.soundEnabled,
+                oneHanded = settings.oneHandedLayout,
+                verticalSwipes = settings.verticalSwipes,
+                orientation = settings.orientation,
+                teams = settings.teams.toList(),
+            )
+    }
+}

--- a/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.example.alias.MainViewModel
 import com.example.alias.R
+import com.example.alias.SettingsUpdateRequest
 import com.example.alias.data.settings.SettingsRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -119,7 +120,7 @@ fun settingsScreen(vm: MainViewModel, onBack: () -> Unit, onAbout: () -> Unit) {
     val applySettings: () -> Job = {
         scope.launch {
             vm.updateSettings(
-                MainViewModel.SettingsUpdateRequest(
+                SettingsUpdateRequest(
                     roundSeconds = round.toIntOrNull() ?: s.roundSeconds,
                     targetWords = target.toIntOrNull() ?: s.targetWords,
                     maxSkips = maxSkips.toIntOrNull() ?: s.maxSkips,

--- a/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
@@ -119,20 +119,22 @@ fun settingsScreen(vm: MainViewModel, onBack: () -> Unit, onAbout: () -> Unit) {
     val applySettings: () -> Job = {
         scope.launch {
             vm.updateSettings(
-                roundSeconds = round.toIntOrNull() ?: s.roundSeconds,
-                targetWords = target.toIntOrNull() ?: s.targetWords,
-                maxSkips = maxSkips.toIntOrNull() ?: s.maxSkips,
-                penaltyPerSkip = penalty.toIntOrNull() ?: s.penaltyPerSkip,
-                punishSkips = punishSkips,
-                language = lang.ifBlank { s.languagePreference },
-                uiLanguage = uiLang,
-                allowNSFW = nsfw,
-                haptics = haptics,
-                sound = sound,
-                oneHanded = oneHand,
-                verticalSwipes = verticalSwipes,
-                orientation = orientation,
-                teams = teams.map { it.name },
+                MainViewModel.SettingsUpdateRequest(
+                    roundSeconds = round.toIntOrNull() ?: s.roundSeconds,
+                    targetWords = target.toIntOrNull() ?: s.targetWords,
+                    maxSkips = maxSkips.toIntOrNull() ?: s.maxSkips,
+                    penaltyPerSkip = penalty.toIntOrNull() ?: s.penaltyPerSkip,
+                    punishSkips = punishSkips,
+                    language = lang.ifBlank { s.languagePreference },
+                    uiLanguage = uiLang,
+                    allowNSFW = nsfw,
+                    haptics = haptics,
+                    sound = sound,
+                    oneHanded = oneHand,
+                    verticalSwipes = verticalSwipes,
+                    orientation = orientation,
+                    teams = teams.map { it.name },
+                ),
             )
         }
     }


### PR DESCRIPTION
## Summary
- add a `SettingsUpdateRequest` data holder in `MainViewModel` to bundle the settings parameters
- refactor `updateSettings` to accept the request object and keep persistence logic unchanged
- update the settings screen to build and pass the new request when saving

## Testing
- `./gradlew spotlessCheck --console=plain`
- `./gradlew detekt --console=plain`
- `./gradlew :domain:test --console=plain`
- `./gradlew :data:test --console=plain`
- `./gradlew :app:testDebugUnitTest --console=plain`
- `./gradlew :app:assembleDebug --console=plain`


------
https://chatgpt.com/codex/tasks/task_b_68cd80fcc904832c92ddc4cb2dd349d9