### PR TITLE
Refactor settings tabs with state containers

### DIFF
--- a/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
@@ -116,6 +116,90 @@ fun settingsScreen(vm: MainViewModel, onBack: () -> Unit, onAbout: () -> Unit) {
     val teamSuggestions = stringArrayResource(R.array.team_name_suggestions).toList()
 
     val canSave = teams.count { it.name.isNotBlank() } >= MIN_TEAMS
+    val matchRulesUiState = MatchRulesUiState(
+        round = round,
+        target = target,
+        maxSkips = maxSkips,
+        penalty = penalty,
+        punishSkips = punishSkips,
+    )
+    val matchRulesActions = MatchRulesActions(
+        onRoundChange = { round = it },
+        onTargetChange = { target = it },
+        onMaxSkipsChange = { maxSkips = it },
+        onPenaltyChange = { penalty = it },
+        onPunishSkipsChange = { punishSkips = it },
+    )
+    val inputFeedbackUiState = InputFeedbackUiState(
+        haptics = haptics,
+        sound = sound,
+        oneHand = oneHand,
+        verticalSwipes = verticalSwipes,
+        orientation = orientation,
+    )
+    val inputFeedbackActions = InputFeedbackActions(
+        onHapticsChange = { haptics = it },
+        onSoundChange = { sound = it },
+        onOneHandChange = { oneHand = it },
+        onVerticalSwipesChange = { verticalSwipes = it },
+        onOrientationChange = { orientation = it },
+    )
+    val teamsUiState = TeamsUiState(
+        teams = teams,
+        canRemoveTeam = teams.size > MIN_TEAMS,
+        canAddTeam = teams.size < MAX_TEAMS,
+        suggestions = teamSuggestions,
+    )
+    val teamsActions = TeamsActions(
+        onTeamNameChange = { index, value ->
+            teams = teams.toMutableList().also { list ->
+                list[index] = list[index].copy(name = value)
+            }
+        },
+        onTeamRemove = { index ->
+            teams = teams.toMutableList().also { it.removeAt(index) }
+        },
+        onTeamAdd = {
+            val defaultName = ctx.getString(R.string.team_default_name, teams.size + 1)
+            teams = teams + TeamEditorEntry(nextTeamId, defaultName)
+            nextTeamId += 1
+        },
+        onTeamMove = move@{ from, to ->
+            if (from == to) return@move
+            if (from !in teams.indices || to !in 0..teams.size) return@move
+            val updated = teams.toMutableList()
+            val item = updated.removeAt(from)
+            val targetIndex = to.coerceIn(0, updated.size)
+            updated.add(targetIndex, item)
+            teams = updated
+        },
+        onApplySuggestion = suggestion@{ suggestion ->
+            if (teams.any { it.name.equals(suggestion, ignoreCase = true) }) return@suggestion
+            val targetIndex = teams.indexOfFirst { it.name.isBlank() }
+            teams = teams.toMutableList().also { list ->
+                when {
+                    targetIndex >= 0 -> list[targetIndex] = list[targetIndex].copy(name = suggestion)
+                    list.size < MAX_TEAMS -> {
+                        list += TeamEditorEntry(nextTeamId, suggestion)
+                        nextTeamId += 1
+                    }
+                }
+            }
+        },
+    )
+    val advancedUiState = AdvancedUiState(
+        uiLanguage = uiLang,
+        language = lang,
+        allowNsfw = nsfw,
+    )
+    val advancedActions = AdvancedActions(
+        onUiLanguageChange = { uiLang = it },
+        onLanguageChange = { lang = it },
+        onAllowNsfwChange = { nsfw = it },
+        onShowTutorialAgain = { vm.updateSeenTutorial(false) },
+        onAbout = onAbout,
+        onReset = { showResetDialog = true },
+    )
     val applySettings: () -> Job = {
         scope.launch {
             vm.updateSettings(
@@ -187,83 +271,23 @@ fun settingsScreen(vm: MainViewModel, onBack: () -> Unit, onAbout: () -> Unit) {
             ) { page ->
                 when (SettingsTab.values()[page]) {
                     SettingsTab.MATCH_RULES -> matchRulesTab(
-                        round = round,
-                        onRoundChange = { round = it },
-                        target = target,
-                        onTargetChange = { target = it },
-                        maxSkips = maxSkips,
-                        onMaxSkipsChange = { maxSkips = it },
-                        penalty = penalty,
-                        onPenaltyChange = { penalty = it },
-                        punishSkips = punishSkips,
-                        onPunishSkipsChange = { punishSkips = it },
+                        state = matchRulesUiState,
+                        actions = matchRulesActions,
                     )
 
                     SettingsTab.INPUT_FEEDBACK -> inputFeedbackTab(
-                        haptics = haptics,
-                        onHapticsChange = { haptics = it },
-                        sound = sound,
-                        onSoundChange = { sound = it },
-                        oneHand = oneHand,
-                        onOneHandChange = { oneHand = it },
-                        verticalSwipes = verticalSwipes,
-                        onVerticalSwipesChange = { verticalSwipes = it },
-                        orientation = orientation,
-                        onOrientationChange = { orientation = it },
+                        state = inputFeedbackUiState,
+                        actions = inputFeedbackActions,
                     )
 
                     SettingsTab.TEAMS -> teamsTab(
-                        teams = teams,
-                        canRemoveTeam = teams.size > MIN_TEAMS,
-                        canAddTeam = teams.size < MAX_TEAMS,
-                        onTeamNameChange = { index, value ->
-                            teams = teams.toMutableList().also { list ->
-                                list[index] = list[index].copy(name = value)
-                            }
-                        },
-                        onTeamRemove = { index ->
-                            teams = teams.toMutableList().also { it.removeAt(index) }
-                        },
-                        onTeamAdd = {
-                            val defaultName = ctx.getString(R.string.team_default_name, teams.size + 1)
-                            teams = teams + TeamEditorEntry(nextTeamId, defaultName)
-                            nextTeamId += 1
-                        },
-                        onTeamMove = { from, to ->
-                            if (from == to) return@teamsTab
-                            if (from !in teams.indices || to !in 0..teams.size) return@teamsTab
-                            val updated = teams.toMutableList()
-                            val item = updated.removeAt(from)
-                            val targetIndex = to.coerceIn(0, updated.size)
-                            updated.add(targetIndex, item)
-                            teams = updated
-                        },
-                        suggestions = teamSuggestions,
-                        onApplySuggestion = { suggestion ->
-                            if (teams.any { it.name.equals(suggestion, ignoreCase = true) }) return@teamsTab
-                            val targetIndex = teams.indexOfFirst { it.name.isBlank() }
-                            teams = teams.toMutableList().also { list ->
-                                when {
-                                    targetIndex >= 0 -> list[targetIndex] = list[targetIndex].copy(name = suggestion)
-                                    list.size < MAX_TEAMS -> {
-                                        list += TeamEditorEntry(nextTeamId, suggestion)
-                                        nextTeamId += 1
-                                    }
-                                }
-                            }
-                        },
+                        state = teamsUiState,
+                        actions = teamsActions,
                     )
 
                     SettingsTab.ADVANCED -> advancedTab(
-                        uiLanguage = uiLang,
-                        onUiLanguageChange = { uiLang = it },
-                        language = lang,
-                        onLanguageChange = { lang = it },
-                        allowNsfw = nsfw,
-                        onAllowNsfwChange = { nsfw = it },
-                        onShowTutorialAgain = { vm.updateSeenTutorial(false) },
-                        onAbout = onAbout,
-                        onReset = { showResetDialog = true },
+                        state = advancedUiState,
+                        actions = advancedActions,
                     )
                 }
             }
@@ -304,6 +328,68 @@ private enum class SettingsTab(@StringRes val titleRes: Int) {
 
 private data class TeamEditorEntry(val id: Long, val name: String)
 
+private data class MatchRulesUiState(
+    val round: String,
+    val target: String,
+    val maxSkips: String,
+    val penalty: String,
+    val punishSkips: Boolean,
+)
+
+private data class MatchRulesActions(
+    val onRoundChange: (String) -> Unit,
+    val onTargetChange: (String) -> Unit,
+    val onMaxSkipsChange: (String) -> Unit,
+    val onPenaltyChange: (String) -> Unit,
+    val onPunishSkipsChange: (Boolean) -> Unit,
+)
+
+private data class InputFeedbackUiState(
+    val haptics: Boolean,
+    val sound: Boolean,
+    val oneHand: Boolean,
+    val verticalSwipes: Boolean,
+    val orientation: String,
+)
+
+private data class InputFeedbackActions(
+    val onHapticsChange: (Boolean) -> Unit,
+    val onSoundChange: (Boolean) -> Unit,
+    val onOneHandChange: (Boolean) -> Unit,
+    val onVerticalSwipesChange: (Boolean) -> Unit,
+    val onOrientationChange: (String) -> Unit,
+)
+
+private data class TeamsUiState(
+    val teams: List<TeamEditorEntry>,
+    val canRemoveTeam: Boolean,
+    val canAddTeam: Boolean,
+    val suggestions: List<String>,
+)
+
+private data class TeamsActions(
+    val onTeamNameChange: (Int, String) -> Unit,
+    val onTeamRemove: (Int) -> Unit,
+    val onTeamAdd: () -> Unit,
+    val onTeamMove: (Int, Int) -> Unit,
+    val onApplySuggestion: (String) -> Unit,
+)
+
+private data class AdvancedUiState(
+    val uiLanguage: String,
+    val language: String,
+    val allowNsfw: Boolean,
+)
+
+private data class AdvancedActions(
+    val onUiLanguageChange: (String) -> Unit,
+    val onLanguageChange: (String) -> Unit,
+    val onAllowNsfwChange: (Boolean) -> Unit,
+    val onShowTutorialAgain: () -> Unit,
+    val onAbout: () -> Unit,
+    val onReset: () -> Unit,
+)
+
 private val TeamEditorEntryStateSaver = listSaver<MutableState<List<TeamEditorEntry>>, Any?>(
     save = { state -> state.value.flatMap { entry -> listOf(entry.id, entry.name) } },
     restore = { restored ->
@@ -318,16 +404,8 @@ private val TeamEditorEntryStateSaver = listSaver<MutableState<List<TeamEditorEn
 
 @Composable
 private fun matchRulesTab(
-    round: String,
-    onRoundChange: (String) -> Unit,
-    target: String,
-    onTargetChange: (String) -> Unit,
-    maxSkips: String,
-    onMaxSkipsChange: (String) -> Unit,
-    penalty: String,
-    onPenaltyChange: (String) -> Unit,
-    punishSkips: Boolean,
-    onPunishSkipsChange: (Boolean) -> Unit,
+    state: MatchRulesUiState,
+    actions: MatchRulesActions,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -339,16 +417,16 @@ private fun matchRulesTab(
                 Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Text(stringResource(R.string.round_and_goals), style = MaterialTheme.typography.titleMedium)
                     OutlinedTextField(
-                        value = round,
-                        onValueChange = onRoundChange,
+                        value = state.round,
+                        onValueChange = actions.onRoundChange,
                         label = { Text(stringResource(R.string.round_seconds_label)) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     )
                     OutlinedTextField(
-                        value = target,
-                        onValueChange = onTargetChange,
+                        value = state.target,
+                        onValueChange = actions.onTargetChange,
                         label = { Text(stringResource(R.string.target_words_label)) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
@@ -363,16 +441,16 @@ private fun matchRulesTab(
                     Text(stringResource(R.string.skips_section), style = MaterialTheme.typography.titleMedium)
                     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                         OutlinedTextField(
-                            value = maxSkips,
-                            onValueChange = onMaxSkipsChange,
+                            value = state.maxSkips,
+                            onValueChange = actions.onMaxSkipsChange,
                             label = { Text(stringResource(R.string.max_skips_label)) },
                             modifier = Modifier.weight(1f),
                             singleLine = true,
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         )
                         OutlinedTextField(
-                            value = penalty,
-                            onValueChange = onPenaltyChange,
+                            value = state.penalty,
+                            onValueChange = actions.onPenaltyChange,
                             label = { Text(stringResource(R.string.penalty_per_skip_label)) },
                             modifier = Modifier.weight(1f),
                             singleLine = true,
@@ -381,7 +459,10 @@ private fun matchRulesTab(
                     }
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(stringResource(R.string.punish_skips_label), modifier = Modifier.weight(1f))
-                        Switch(checked = punishSkips, onCheckedChange = onPunishSkipsChange)
+                        Switch(
+                            checked = state.punishSkips,
+                            onCheckedChange = actions.onPunishSkipsChange,
+                        )
                     }
                 }
             }
@@ -392,16 +473,8 @@ private fun matchRulesTab(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun inputFeedbackTab(
-    haptics: Boolean,
-    onHapticsChange: (Boolean) -> Unit,
-    sound: Boolean,
-    onSoundChange: (Boolean) -> Unit,
-    oneHand: Boolean,
-    onOneHandChange: (Boolean) -> Unit,
-    verticalSwipes: Boolean,
-    onVerticalSwipesChange: (Boolean) -> Unit,
-    orientation: String,
-    onOrientationChange: (String) -> Unit,
+    state: InputFeedbackUiState,
+    actions: InputFeedbackActions,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -414,23 +487,23 @@ private fun inputFeedbackTab(
                     Text(stringResource(R.string.feedback_and_layout), style = MaterialTheme.typography.titleMedium)
                     settingsToggleRow(
                         label = stringResource(R.string.haptics_label),
-                        checked = haptics,
-                        onCheckedChange = onHapticsChange,
+                        checked = state.haptics,
+                        onCheckedChange = actions.onHapticsChange,
                     )
                     settingsToggleRow(
                         label = stringResource(R.string.sound_effects_label),
-                        checked = sound,
-                        onCheckedChange = onSoundChange,
+                        checked = state.sound,
+                        onCheckedChange = actions.onSoundChange,
                     )
                     settingsToggleRow(
                         label = stringResource(R.string.one_hand_layout_label),
-                        checked = oneHand,
-                        onCheckedChange = onOneHandChange,
+                        checked = state.oneHand,
+                        onCheckedChange = actions.onOneHandChange,
                     )
                     settingsToggleRow(
                         label = stringResource(R.string.vertical_swipes_label),
-                        checked = verticalSwipes,
-                        onCheckedChange = onVerticalSwipesChange,
+                        checked = state.verticalSwipes,
+                        onCheckedChange = actions.onVerticalSwipesChange,
                     )
                 }
             }
@@ -445,22 +518,22 @@ private fun inputFeedbackTab(
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         orientationChip(
-                            selected = orientation == "system",
+                            selected = state.orientation == "system",
                             label = stringResource(R.string.auto_label),
                             icon = Icons.Filled.ScreenRotation,
-                            onClick = { onOrientationChange("system") },
+                            onClick = { actions.onOrientationChange("system") },
                         )
                         orientationChip(
-                            selected = orientation == "portrait",
+                            selected = state.orientation == "portrait",
                             label = stringResource(R.string.portrait_label),
                             icon = Icons.Filled.ScreenLockPortrait,
-                            onClick = { onOrientationChange("portrait") },
+                            onClick = { actions.onOrientationChange("portrait") },
                         )
                         orientationChip(
-                            selected = orientation == "landscape",
+                            selected = state.orientation == "landscape",
                             label = stringResource(R.string.landscape_label),
                             icon = Icons.Filled.ScreenLockLandscape,
-                            onClick = { onOrientationChange("landscape") },
+                            onClick = { actions.onOrientationChange("landscape") },
                         )
                     }
                 }
@@ -499,15 +572,8 @@ private fun orientationChip(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun teamsTab(
-    teams: List<TeamEditorEntry>,
-    canRemoveTeam: Boolean,
-    canAddTeam: Boolean,
-    onTeamNameChange: (Int, String) -> Unit,
-    onTeamRemove: (Int) -> Unit,
-    onTeamAdd: () -> Unit,
-    onTeamMove: (Int, Int) -> Unit,
-    suggestions: List<String>,
-    onApplySuggestion: (String) -> Unit,
+    state: TeamsUiState,
+    actions: TeamsActions,
 ) {
     val itemHeights = remember { mutableStateMapOf<Int, Int>() }
     var draggingIndex by remember { mutableStateOf<Int?>(null) }
@@ -528,19 +594,19 @@ private fun teamsTab(
                 )
             }
         }
-        itemsIndexed(teams, key = { _, team -> team.id }) { index, team ->
+        itemsIndexed(state.teams, key = { _, team -> team.id }) { index, team ->
             val isDragging = draggingIndex == index
             teamEditorCard(
                 index = index,
                 name = team.name,
-                canRemove = canRemoveTeam,
-                onNameChange = onTeamNameChange,
-                onRemove = onTeamRemove,
+                canRemove = state.canRemoveTeam,
+                onNameChange = actions.onTeamNameChange,
+                onRemove = actions.onTeamRemove,
                 modifier = Modifier
                     .fillMaxWidth()
                     .onGloballyPositioned { coords -> itemHeights[index] = coords.size.height }
                     .graphicsLayer { translationY = if (isDragging) dragOffset else 0f },
-                handleModifier = Modifier.pointerInput(teams) {
+                handleModifier = Modifier.pointerInput(state.teams) {
                     detectDragGesturesAfterLongPress(
                         onDragStart = {
                             draggingIndex = index
@@ -550,17 +616,17 @@ private fun teamsTab(
                             change.consume()
                             val current = draggingIndex ?: return@detectDragGesturesAfterLongPress
                             dragOffset += dragAmount.y
-                            if (dragOffset > 0 && current < teams.lastIndex) {
+                            if (dragOffset > 0 && current < state.teams.lastIndex) {
                                 val height = itemHeights[current + 1] ?: return@detectDragGesturesAfterLongPress
                                 if (dragOffset > height * 0.6f) {
-                                    onTeamMove(current, current + 1)
+                                    actions.onTeamMove(current, current + 1)
                                     draggingIndex = current + 1
                                     dragOffset = 0f
                                 }
                             } else if (dragOffset < 0 && current > 0) {
                                 val height = itemHeights[current - 1] ?: return@detectDragGesturesAfterLongPress
                                 if (dragOffset < -height * 0.6f) {
-                                    onTeamMove(current, current - 1)
+                                    actions.onTeamMove(current, current - 1)
                                     draggingIndex = current - 1
                                     dragOffset = 0f
                                 }
@@ -581,11 +647,11 @@ private fun teamsTab(
         }
         item {
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Button(onClick = onTeamAdd, enabled = canAddTeam, modifier = Modifier.weight(1f)) {
+                Button(onClick = actions.onTeamAdd, enabled = state.canAddTeam, modifier = Modifier.weight(1f)) {
                     Text(stringResource(R.string.add_team_label))
                 }
                 OutlinedButton(
-                    onClick = { suggestions.randomOrNull()?.let(onApplySuggestion) },
+                    onClick = { state.suggestions.randomOrNull()?.let(actions.onApplySuggestion) },
                     modifier = Modifier.weight(1f),
                 ) {
                     Text(stringResource(R.string.team_suggestions_label))
@@ -605,8 +671,11 @@ private fun teamsTab(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        suggestions.forEach { suggestion ->
-                            SuggestionChip(onClick = { onApplySuggestion(suggestion) }, label = { Text(suggestion) })
+                        state.suggestions.forEach { suggestion ->
+                            SuggestionChip(
+                                onClick = { actions.onApplySuggestion(suggestion) },
+                                label = { Text(suggestion) },
+                            )
                         }
                     }
                 }
@@ -676,17 +745,10 @@ private fun teamEditorCard(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun advancedTab(
-    uiLanguage: String,
-    onUiLanguageChange: (String) -> Unit,
-    language: String,
-    onLanguageChange: (String) -> Unit,
-    allowNsfw: Boolean,
-    onAllowNsfwChange: (Boolean) -> Unit,
-    onShowTutorialAgain: () -> Unit,
-    onAbout: () -> Unit,
-    onReset: () -> Unit,
+    state: AdvancedUiState,
+    actions: AdvancedActions,
 ) {
-    val selectedLanguage = remember(uiLanguage) { resolveUiLanguageSelection(uiLanguage) }
+    val selectedLanguage = remember(state.uiLanguage) { resolveUiLanguageSelection(state.uiLanguage) }
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -704,30 +766,30 @@ private fun advancedTab(
                     ) {
                         FilterChip(
                             selected = selectedLanguage == "system",
-                            onClick = { onUiLanguageChange("system") },
+                            onClick = { actions.onUiLanguageChange("system") },
                             label = { Text(stringResource(R.string.system_default_label)) },
                         )
                         FilterChip(
                             selected = selectedLanguage == "en",
-                            onClick = { onUiLanguageChange("en") },
+                            onClick = { actions.onUiLanguageChange("en") },
                             label = { Text(stringResource(R.string.english_label)) },
                         )
                         FilterChip(
                             selected = selectedLanguage == "ru",
-                            onClick = { onUiLanguageChange("ru") },
+                            onClick = { actions.onUiLanguageChange("ru") },
                             label = { Text(stringResource(R.string.russian_label)) },
                         )
                     }
                     OutlinedTextField(
-                        value = language,
-                        onValueChange = onLanguageChange,
+                        value = state.language,
+                        onValueChange = actions.onLanguageChange,
                         label = { Text(stringResource(R.string.language_hint)) },
                         modifier = Modifier.fillMaxWidth(),
                     )
                     settingsToggleRow(
                         label = stringResource(R.string.allow_nsfw_label),
-                        checked = allowNsfw,
-                        onCheckedChange = onAllowNsfwChange,
+                        checked = state.allowNsfw,
+                        onCheckedChange = actions.onAllowNsfwChange,
                     )
                 }
             }
@@ -739,19 +801,19 @@ private fun advancedTab(
                     ListItem(
                         leadingContent = { Icon(Icons.Filled.History, contentDescription = null) },
                         headlineContent = { Text(stringResource(R.string.show_tutorial_again)) },
-                        modifier = Modifier.clickable { onShowTutorialAgain() },
+                        modifier = Modifier.clickable { actions.onShowTutorialAgain() },
                     )
                     HorizontalDivider()
                     ListItem(
                         leadingContent = { Icon(Icons.Filled.Info, contentDescription = null) },
                         headlineContent = { Text(stringResource(R.string.title_about)) },
-                        modifier = Modifier.clickable(onClick = onAbout),
+                        modifier = Modifier.clickable(onClick = actions.onAbout),
                     )
                     HorizontalDivider()
                     ListItem(
                         leadingContent = { Icon(Icons.Filled.Delete, contentDescription = null) },
                         headlineContent = { Text(stringResource(R.string.reset_local_data)) },
-                        modifier = Modifier.clickable { onReset() },
+                        modifier = Modifier.clickable { actions.onReset() },
                     )
                 }
             }

--- a/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
@@ -152,12 +152,12 @@ fun settingsScreen(vm: MainViewModel, onBack: () -> Unit, onAbout: () -> Unit) {
     )
     val teamsActions = TeamsActions(
         onTeamNameChange = { index, value ->
-            teams = teams.toMutableList().also { list ->
-                list[index] = list[index].copy(name = value)
+            teams = teams.mapIndexed { i, team ->
+                if (i == index) team.copy(name = value) else team
             }
         },
         onTeamRemove = { index ->
-            teams = teams.toMutableList().also { it.removeAt(index) }
+            teams = teams.toMutableList().apply { removeAt(index) }
         },
         onTeamAdd = {
             val defaultName = ctx.getString(R.string.team_default_name, teams.size + 1)
@@ -176,11 +176,11 @@ fun settingsScreen(vm: MainViewModel, onBack: () -> Unit, onAbout: () -> Unit) {
         onApplySuggestion = suggestion@{ suggestion ->
             if (teams.any { it.name.equals(suggestion, ignoreCase = true) }) return@suggestion
             val targetIndex = teams.indexOfFirst { it.name.isBlank() }
-            teams = teams.toMutableList().also { list ->
+            teams = teams.toMutableList().apply {
                 when {
-                    targetIndex >= 0 -> list[targetIndex] = list[targetIndex].copy(name = suggestion)
-                    list.size < MAX_TEAMS -> {
-                        list += TeamEditorEntry(nextTeamId, suggestion)
+                    targetIndex >= 0 -> this[targetIndex] = this[targetIndex].copy(name = suggestion)
+                    size < MAX_TEAMS -> {
+                        add(TeamEditorEntry(nextTeamId, suggestion))
                         nextTeamId += 1
                     }
                 }


### PR DESCRIPTION
## Summary
- group tab-specific settings values and callbacks into dedicated state/action containers
- update each settings tab to consume the new containers instead of long parameter lists
- wire the settings screen to build the containers from MainViewModel state before invoking the tabs

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_b_68cd81072f88832c9fd3627e1a09279d