### PR TITLE
Update TODO backlog for upcoming features

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,8 +30,15 @@
 ## Backlog
 - Bundled assets change detection: implemented; consider per-deck id tracking and pruning removed assets.
 - Room migrations: implement proper migrations for DB version upgrades; remove destructive fallback in production builds.
-- Localization: complete pass for any residual literals (e.g., minor labels) to `strings.xml`.
+- Add toggleable score-to-target regime with configurable goal in Settings and wire it into game flow.
+- Localization: ensure *all* strings (including Settings, About, and any new UI) are fully externalized.
+- Refactor end-of-turn summary UI: relocate turn statistics, collapse detailed breakdown/time graph (taller), per-word blocks with colored backgrounds acting as correct/incorrect toggles, and show time-between-word graph.
+- Update History screen: hide filters/stats by default, add Reset History action, and align detailed game view with end-of-turn summary layout.
+- Deck details: ensure recent words pull from games played with the selected deck.
+- Refactor game image loading pipeline for robustness/performance.
 - Tests:
   - Repository: verify re-import of the same deck does not duplicate words (and that updated decks replace content).
   - App-layer: verify last-turn outcomes are persisted when match ends (target reached or timer with no words left).
   - Engine: property-like tests for multi-team rotation and cumulative scoring across many turns.
+- Deck language handling: remove deck language setting from Settings, add per-deck language filters in Decks, and enforce language metadata rules for mono/multi-lingual packs.
+- Audio UX: add sound hooks for countdown, turn start, final 5 seconds with vibration, and turn end (no assets committed).


### PR DESCRIPTION
## Summary
- add backlog item for configurable score-to-target regime
- expand localization and UI refactor tasks across end-turn and history screens
- capture follow-up work for decks, media loading, and new audio cues

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cdce18259c832cbd9effe4eb17b9a4