### PR TITLE
Refactor MainViewModel collaborators

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,4 +104,5 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.bundles.test.unit)
+    testImplementation(libs.okhttp)
 }

--- a/app/src/main/java/com/example/alias/DeckManager.kt
+++ b/app/src/main/java/com/example/alias/DeckManager.kt
@@ -1,0 +1,531 @@
+package com.example.alias
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.util.Base64
+import android.util.Log
+import com.example.alias.data.DeckRepository
+import com.example.alias.data.db.DeckDao
+import com.example.alias.data.db.DeckEntity
+import com.example.alias.data.db.DifficultyBucket
+import com.example.alias.data.db.TurnHistoryDao
+import com.example.alias.data.db.WordClassCount
+import com.example.alias.data.db.WordDao
+import com.example.alias.data.download.PackDownloader
+import com.example.alias.data.pack.PackParser
+import com.example.alias.data.pack.ParsedPack
+import com.example.alias.data.settings.Settings
+import com.example.alias.data.settings.SettingsRepository
+import com.example.alias.domain.word.WordClassCatalog
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.security.MessageDigest
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
+
+@Singleton
+class DeckManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val deckRepository: DeckRepository,
+    private val wordDao: WordDao,
+    private val deckDao: DeckDao,
+    private val turnHistoryDao: TurnHistoryDao,
+    private val settingsRepository: SettingsRepository,
+    private val downloader: PackDownloader,
+) {
+    data class InitialLoadResult(
+        val words: List<String>,
+        val settings: Settings,
+    )
+
+    data class WordQueryFilters(
+        val deckIds: List<String>,
+        val language: String,
+        val allowNSFW: Boolean,
+        val minDifficulty: Int,
+        val maxDifficulty: Int,
+        val categories: List<String>,
+        val categoryFilterEnabled: Int,
+        val wordClasses: List<String>,
+        val wordClassFilterEnabled: Int,
+    )
+
+    data class PackImportResult(
+        val deckId: String,
+        val language: String,
+        val coverImageError: Throwable?,
+    )
+
+    sealed class DeleteDeckResult {
+        data class Success(val message: String) : DeleteDeckResult()
+        data class Failure(val errorMessage: String) : DeleteDeckResult()
+    }
+
+    data class WordClassAvailabilityKey(
+        val deckIds: Set<String>,
+        val language: String,
+        val allowNSFW: Boolean,
+    )
+
+    fun observeDecks(): Flow<List<DeckEntity>> {
+        return deckRepository.getDecks()
+            .combine(settingsRepository.settings.map { it.deletedBundledDeckIds }) { allDecks, deletedIds ->
+                val filtered = allDecks.filter { deck -> !deletedIds.contains(deck.id) }
+                Log.d(TAG, "Filtered decks: ${filtered.size} (removed ${allDecks.size - filtered.size})")
+                filtered
+            }
+    }
+
+    fun observeEnabledDeckIds(): Flow<Set<String>> = settingsRepository.settings.map { it.enabledDeckIds }
+
+    fun observeTrustedSources(): Flow<Set<String>> = settingsRepository.settings.map { it.trustedSources }
+
+    fun observeSettings(): Flow<Settings> = settingsRepository.settings
+
+    suspend fun prepareInitialLoad(): InitialLoadResult {
+        return withContext(Dispatchers.IO) {
+            val assetFiles = context.assets.list("decks")?.filter { it.endsWith(".json") } ?: emptyList()
+            val previousHashes = settingsRepository.readBundledDeckHashes()
+            val digest = MessageDigest.getInstance("SHA-256")
+            fun sha256(bytes: ByteArray): String = digest.digest(bytes).joinToString("") { b -> "%02x".format(b) }
+
+            val assetContents = mutableMapOf<String, String>()
+            val currentDeckEntries = mutableSetOf<String>()
+            val toImport = mutableListOf<String>()
+            val currentBundledDeckIds = mutableSetOf<String>()
+            val deletedBundledDeckIds = settingsRepository.readDeletedBundledDeckIds()
+
+            assetFiles.forEach { file ->
+                val content = runCatching {
+                    context.assets.open("decks/$file").bufferedReader().use { it.readText() }
+                }.getOrNull()
+                if (content != null) {
+                    assetContents[file] = content
+                    val bytes = content.toByteArray(Charsets.UTF_8)
+                    val fileHash = sha256(bytes)
+                    val deckIds = parseDeckIdsFromContent(content)
+                    currentBundledDeckIds += deckIds
+
+                    deckIds.forEach { deckId ->
+                        currentDeckEntries += "$deckId:$fileHash"
+                    }
+                    currentDeckEntries += "$file:$fileHash"
+
+                    val fileNeedsImport = previousHashes.none { it.startsWith("$file:") } || !previousHashes.contains("$file:$fileHash")
+                    val decksNeedImport = deckIds.any { deckId ->
+                        val deckEntry = "$deckId:$fileHash"
+                        !deletedBundledDeckIds.contains(deckId) &&
+                            (previousHashes.none { it.startsWith("$deckId:") } || !previousHashes.contains(deckEntry))
+                    }
+                    if (fileNeedsImport || decksNeedImport) {
+                        toImport += file
+                    }
+                } else {
+                    Log.e(TAG, "Failed to read bundled deck $file")
+                }
+            }
+
+            val allDecks = deckRepository.getDecks().first()
+            val decksToPrune = allDecks.filter { deck ->
+                deck.isOfficial && currentBundledDeckIds.contains(deck.id) && !deletedBundledDeckIds.contains(deck.id)
+            }
+            decksToPrune.forEach { deck ->
+                runCatching { deckRepository.deleteDeck(deck.id) }
+                    .onFailure { Log.e(TAG, "Failed to prune deck ${deck.id}", it) }
+            }
+
+            if (previousHashes.isEmpty() && currentDeckEntries.isNotEmpty()) {
+                toImport.clear()
+                toImport.addAll(assetFiles)
+            }
+            val hadDecks = allDecks.isNotEmpty()
+            if (!hadDecks && assetFiles.isNotEmpty()) {
+                toImport.clear()
+                toImport.addAll(assetFiles)
+            }
+
+            toImport.forEach { file ->
+                runCatching {
+                    val content = assetContents[file]
+                        ?: context.assets.open("decks/$file").bufferedReader().use { it.readText() }
+                    val sanitized = parseAndSanitizePack(content, isBundledAsset = true)
+                    deckRepository.importPack(sanitized.pack)
+                    sanitized.coverImageError?.let {
+                        Log.w(TAG, "Bundled deck $file cover art discarded", it)
+                    }
+                }.onFailure { Log.e(TAG, "Failed to import bundled deck $file", it) }
+            }
+
+            runCatching { settingsRepository.writeBundledDeckHashes(currentDeckEntries) }
+                .onFailure { Log.e(TAG, "Failed to persist bundled deck hashes", it) }
+
+            val baseSettings = settingsRepository.settings.first()
+            val allDecksAfterImport = deckRepository.getDecks().first()
+            val availableDecks = allDecksAfterImport.filter { !deletedBundledDeckIds.contains(it.id) }
+            val preferredIds = availableDecks
+                .filter { it.language == baseSettings.languagePreference }
+                .map { it.id }
+                .toSet()
+            val fallbackIds = availableDecks.map { it.id }.toSet()
+            val resolvedEnabled = if (baseSettings.enabledDeckIds.isEmpty()) {
+                if (preferredIds.isNotEmpty()) preferredIds else fallbackIds
+            } else {
+                baseSettings.enabledDeckIds.filterNot { deletedBundledDeckIds.contains(it) }.toSet()
+            }
+
+            if (baseSettings.enabledDeckIds.isEmpty()) {
+                runCatching { settingsRepository.setEnabledDeckIds(resolvedEnabled) }
+                    .onFailure { Log.e(TAG, "Failed to persist enabled deck ids", it) }
+            }
+
+            val filters = buildWordQueryFilters(baseSettings, resolvedEnabled)
+            val words = loadWords(filters)
+
+            InitialLoadResult(
+                words = words,
+                settings = baseSettings.copy(enabledDeckIds = resolvedEnabled),
+            )
+        }
+    }
+
+    fun buildWordQueryFilters(settings: Settings, deckIdsOverride: Set<String>? = null): WordQueryFilters {
+        val deckIds = (deckIdsOverride ?: settings.enabledDeckIds).toList()
+        val categories = settings.selectedCategories.toList()
+        val classes = canonicalizeWordClassFilters(settings.selectedWordClasses)
+        return WordQueryFilters(
+            deckIds = deckIds,
+            language = settings.languagePreference,
+            allowNSFW = settings.allowNSFW,
+            minDifficulty = settings.minDifficulty,
+            maxDifficulty = settings.maxDifficulty,
+            categories = categories,
+            categoryFilterEnabled = if (categories.isEmpty()) 0 else 1,
+            wordClasses = classes,
+            wordClassFilterEnabled = if (classes.isEmpty()) 0 else 1,
+        )
+    }
+
+    suspend fun loadWords(filters: WordQueryFilters): List<String> {
+        if (filters.deckIds.isEmpty()) return emptyList()
+        return withContext(Dispatchers.IO) {
+            wordDao.getWordTextsForDecks(
+                filters.deckIds,
+                filters.language,
+                filters.allowNSFW,
+                filters.minDifficulty,
+                filters.maxDifficulty,
+                filters.categories,
+                filters.categoryFilterEnabled,
+                filters.wordClasses,
+                filters.wordClassFilterEnabled,
+            )
+        }
+    }
+
+    suspend fun loadWordMetadata(filters: WordQueryFilters): WordMetadata {
+        if (filters.deckIds.isEmpty()) {
+            return WordMetadata(emptyMap(), emptyList(), emptyList())
+        }
+        return withContext(Dispatchers.IO) {
+            coroutineScope {
+                val briefsDeferred = async {
+                    wordDao.getWordBriefsForDecks(
+                        filters.deckIds,
+                        filters.language,
+                        filters.allowNSFW,
+                        filters.minDifficulty,
+                        filters.maxDifficulty,
+                        filters.categories,
+                        filters.categoryFilterEnabled,
+                        filters.wordClasses,
+                        filters.wordClassFilterEnabled,
+                    )
+                }
+                val categoriesDeferred = async {
+                    wordDao.getAvailableCategories(filters.deckIds, filters.language, filters.allowNSFW)
+                }
+                val classesDeferred = async {
+                    wordDao.getAvailableWordClasses(filters.deckIds, filters.language, filters.allowNSFW)
+                }
+                val briefs = briefsDeferred.await()
+                val categories = categoriesDeferred.await().sorted()
+                val classes = classesDeferred.await()
+                val infoByWord = briefs.associateBy({ it.text }) { brief ->
+                    WordInfo(brief.difficulty, brief.category, parsePrimaryWordClass(brief.wordClass))
+                }
+                WordMetadata(
+                    infoByWord = infoByWord,
+                    categories = categories,
+                    wordClasses = canonicalizeWordClassFilters(classes),
+                )
+            }
+        }
+    }
+
+    fun canonicalizeWordClassFilters(raw: Collection<String>): List<String> {
+        val normalized = raw
+            .asSequence()
+            .mapNotNull { value ->
+                val trimmed = value.trim()
+                if (trimmed.isEmpty()) {
+                    null
+                } else {
+                    trimmed.uppercase(Locale.ROOT)
+                }
+            }
+            .toList()
+        if (normalized.isEmpty()) return emptyList()
+        val orderedKnown = WordClassCatalog.order(normalized)
+        val knownSet = orderedKnown.toSet()
+        val extras = normalized
+            .asSequence()
+            .filterNot { knownSet.contains(it) }
+            .distinct()
+            .sorted()
+            .toList()
+        return orderedKnown + extras
+    }
+
+    fun parsePrimaryWordClass(raw: String?): String? {
+        return raw
+            ?.split(',')
+            ?.asSequence()
+            ?.mapNotNull { WordClassCatalog.normalizeOrNull(it) }
+            ?.firstOrNull()
+    }
+
+    suspend fun downloadPack(
+        url: String,
+        expectedSha256: String?,
+        onProgress: (bytesRead: Long, totalBytes: Long?) -> Unit,
+    ): ByteArray {
+        return withContext(Dispatchers.IO) {
+            downloader.download(
+                url.trim(),
+                expectedSha256?.trim().takeUnless { it.isNullOrEmpty() },
+            ) { bytesRead, totalBytes ->
+                onProgress(bytesRead, totalBytes)
+            }
+        }
+    }
+
+    suspend fun importDeckFromUri(uri: Uri): PackImportResult {
+        val text = withContext(Dispatchers.IO) {
+            context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+                ?: throw IllegalStateException("Empty file")
+        }
+        return importPackFromJson(text)
+    }
+
+    suspend fun importPackFromJson(content: String, isBundledAsset: Boolean = false): PackImportResult {
+        val sanitized = parseAndSanitizePack(content, isBundledAsset)
+        withContext(Dispatchers.IO) { deckRepository.importPack(sanitized.pack) }
+        return PackImportResult(
+            deckId = sanitized.pack.deck.id,
+            language = sanitized.pack.deck.language,
+            coverImageError = sanitized.coverImageError,
+        )
+    }
+
+    suspend fun setDeckEnabled(id: String, enabled: Boolean) {
+        val current = settingsRepository.settings.first().enabledDeckIds.toMutableSet()
+        if (enabled) current += id else current -= id
+        settingsRepository.setEnabledDeckIds(current)
+    }
+
+    suspend fun setAllDecksEnabled(enableAll: Boolean) {
+        val all = deckRepository.getDecks().first().map { it.id }.toSet()
+        val target = if (enableAll) all else emptySet()
+        settingsRepository.setEnabledDeckIds(target)
+    }
+
+    suspend fun deleteDeck(deck: DeckEntity): DeleteDeckResult {
+        val settingsSnapshot = settingsRepository.settings.first()
+        val updatedIds = settingsSnapshot.enabledDeckIds - deck.id
+        val isBundledDeck = deck.isOfficial
+        val result = runCatching {
+            withContext(Dispatchers.IO) {
+                if (isBundledDeck) {
+                    settingsRepository.addDeletedBundledDeckId(deck.id)
+                    settingsRepository.setEnabledDeckIds(updatedIds)
+                } else {
+                    deckRepository.deleteDeck(deck.id)
+                }
+            }
+        }
+        if (result.isFailure) {
+            val error = result.exceptionOrNull()?.message ?: "Unknown error"
+            return DeleteDeckResult.Failure(error)
+        }
+        if (updatedIds != settingsSnapshot.enabledDeckIds) {
+            settingsRepository.setEnabledDeckIds(updatedIds)
+        }
+        val message = if (isBundledDeck) {
+            "Hidden deck: ${deck.name}"
+        } else {
+            "Deleted deck: ${deck.name}"
+        }
+        return DeleteDeckResult.Success(message)
+    }
+
+    suspend fun permanentlyDeleteImportedDeck(deck: DeckEntity): Result<Unit> {
+        return runCatching {
+            withContext(Dispatchers.IO) { deckRepository.deleteDeck(deck.id) }
+        }
+    }
+
+    suspend fun restoreDeletedBundledDeck(deckId: String): Result<Unit> {
+        return runCatching {
+            withContext(Dispatchers.IO) {
+                settingsRepository.removeDeletedBundledDeckId(deckId)
+            }
+        }
+    }
+
+    suspend fun getWordCount(deckId: String): Int = deckRepository.getWordCount(deckId)
+
+    suspend fun getDeckCategories(deckId: String): List<String> = withContext(Dispatchers.IO) { wordDao.getDeckCategories(deckId) }
+
+    suspend fun getDeckWordSamples(deckId: String, limit: Int = 5): List<String> =
+        withContext(Dispatchers.IO) { wordDao.getRandomWordSamples(deckId, limit) }
+
+    suspend fun getDeckDifficultyHistogram(deckId: String): List<DifficultyBucket> =
+        withContext(Dispatchers.IO) { deckRepository.getDifficultyHistogram(deckId) }
+
+    suspend fun getDeckRecentWords(deckId: String, limit: Int = 8): List<String> =
+        withContext(Dispatchers.IO) { deckRepository.getRecentWords(deckId, limit) }
+
+    suspend fun getDeckWordClassCounts(deckId: String): List<WordClassCount> =
+        withContext(Dispatchers.IO) {
+            val counts = wordDao.getWordClassCounts(deckId)
+            val knownOrder = WordClassCatalog.allowed.withIndex().associate { it.value to it.index }
+            counts.sortedWith(
+                compareBy(
+                    { knownOrder[it.wordClass] ?: Int.MAX_VALUE },
+                    { it.wordClass },
+                ),
+            )
+        }
+
+    suspend fun resetLocalData() {
+        withContext(Dispatchers.IO) {
+            turnHistoryDao.deleteAll()
+            deckDao.deleteAll()
+            settingsRepository.clearAll()
+        }
+    }
+
+    fun buildWordClassAvailabilityKey(settings: Settings): WordClassAvailabilityKey =
+        WordClassAvailabilityKey(
+            deckIds = settings.enabledDeckIds,
+            language = settings.languagePreference,
+            allowNSFW = settings.allowNSFW,
+        )
+
+    suspend fun loadAvailableWordClasses(key: WordClassAvailabilityKey): List<String> {
+        val ids = key.deckIds.toList()
+        if (ids.isEmpty()) return emptyList()
+        val classes = withContext(Dispatchers.IO) {
+            wordDao.getAvailableWordClasses(ids, key.language, key.allowNSFW)
+        }
+        return canonicalizeWordClassFilters(classes)
+    }
+
+    private data class SanitizedPack(
+        val pack: ParsedPack,
+        val coverImageError: Throwable?,
+    )
+
+    private fun parseDeckIdsFromContent(content: String): List<String> {
+        return try {
+            val root = JSONObject(content)
+            val deck = root.optJSONObject("deck")
+            if (deck != null && deck.has("id")) {
+                listOf(deck.getString("id"))
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse deck IDs from content", e)
+            emptyList()
+        }
+    }
+
+    private suspend fun sanitizeCoverImage(pack: ParsedPack): SanitizedPack {
+        val coverError = withContext(Dispatchers.IO) {
+            pack.deck.coverImageBase64?.let { encoded ->
+                try {
+                    val decoded = Base64.decode(encoded, Base64.DEFAULT)
+                    require(decoded.isNotEmpty()) { "Cover image is empty" }
+                    val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                    BitmapFactory.decodeByteArray(decoded, 0, decoded.size, opts)
+                    require(opts.outWidth > 0 && opts.outHeight > 0) { "Cover image has invalid dimensions" }
+                    null
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (t: Throwable) {
+                    Log.e(TAG, "Failed to decode deck cover image for ${pack.deck.id}", t)
+                    t
+                }
+            }
+        }
+        val sanitized = if (coverError != null) {
+            pack.copy(deck = pack.deck.copy(coverImageBase64 = null))
+        } else {
+            pack
+        }
+        return SanitizedPack(sanitized, coverError)
+    }
+
+    private suspend fun parseAndSanitizePack(content: String, isBundledAsset: Boolean = false): SanitizedPack {
+        return try {
+            val parsed = PackParser.fromJson(content, isBundledAsset)
+            sanitizeCoverImage(parsed)
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            if (!error.isCoverImageError()) throw error
+            val sanitizedJson = removeCoverImageField(content) ?: throw error
+            val parsed = PackParser.fromJson(sanitizedJson, isBundledAsset)
+            val sanitized = sanitizeCoverImage(parsed)
+            sanitized.copy(coverImageError = sanitized.coverImageError ?: error)
+        }
+    }
+
+    private fun removeCoverImageField(content: String): String? {
+        return try {
+            val root = JSONObject(content)
+            val deck = root.optJSONObject("deck") ?: return null
+            if (!deck.has("coverImage")) {
+                null
+            } else {
+                deck.remove("coverImage")
+                root.toString()
+            }
+        } catch (error: Exception) {
+            null
+        }
+    }
+
+    private fun Throwable.isCoverImageError(): Boolean {
+        if (this is IllegalArgumentException && message?.contains("cover image", ignoreCase = true) == true) {
+            return true
+        }
+        val cause = cause
+        return cause != null && cause !== this && cause.isCoverImageError()
+    }
+
+    companion object {
+        private const val TAG = "DeckManager"
+    }
+}

--- a/app/src/main/java/com/example/alias/GameController.kt
+++ b/app/src/main/java/com/example/alias/GameController.kt
@@ -1,0 +1,62 @@
+package com.example.alias
+
+import com.example.alias.data.TurnHistoryRepository
+import com.example.alias.data.db.TurnHistoryEntity
+import com.example.alias.data.settings.Settings
+import com.example.alias.domain.GameEngine
+import com.example.alias.domain.GameState
+import com.example.alias.domain.MatchConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import java.security.SecureRandom
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GameController @Inject constructor(
+    private val historyRepository: TurnHistoryRepository,
+) {
+    fun createEngine(words: List<String>, scope: CoroutineScope): GameEngine {
+        return com.example.alias.domain.DefaultGameEngine(words, scope)
+    }
+
+    suspend fun startMatch(engine: GameEngine, settings: Settings) {
+        val config = MatchConfig(
+            targetWords = settings.targetWords,
+            maxSkips = settings.maxSkips,
+            penaltyPerSkip = if (settings.punishSkips) settings.penaltyPerSkip else 0,
+            roundSeconds = settings.roundSeconds,
+        )
+        val seed = SecureRandom().nextLong()
+        engine.startMatch(config, teams = settings.teams, seed = seed)
+    }
+
+    suspend fun completeTurn(engine: GameEngine, infoByWord: Map<String, WordInfo>) {
+        val current = engine.state.value
+        if (current is GameState.TurnFinished) {
+            val entries = current.outcomes.map { outcome ->
+                TurnHistoryEntity(
+                    id = 0L,
+                    team = current.team,
+                    word = outcome.word,
+                    correct = outcome.correct,
+                    skipped = outcome.skipped,
+                    difficulty = infoByWord[outcome.word]?.difficulty,
+                    timestamp = outcome.timestamp,
+                )
+            }
+            historyRepository.save(entries)
+            engine.nextTurn()
+        }
+    }
+
+    suspend fun startTurn(engine: GameEngine) {
+        engine.startTurn()
+    }
+
+    suspend fun overrideOutcome(engine: GameEngine, index: Int, correct: Boolean) {
+        engine.overrideOutcome(index, correct)
+    }
+
+    fun recentHistory(limit: Int): Flow<List<TurnHistoryEntity>> = historyRepository.getRecent(limit)
+}

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -3,7 +3,6 @@ package com.example.alias
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.WindowCompat
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
@@ -13,6 +12,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
 import com.example.alias.MainViewModel.UiEvent

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -1,36 +1,18 @@
 package com.example.alias
 
-import android.content.Context
-import android.graphics.BitmapFactory
 import android.net.Uri
-import android.util.Base64
 import android.util.Log
 import androidx.compose.material3.SnackbarDuration
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.alias.data.DeckRepository
-import com.example.alias.data.TurnHistoryRepository
 import com.example.alias.data.db.DeckEntity
 import com.example.alias.data.db.DifficultyBucket
 import com.example.alias.data.db.TurnHistoryEntity
 import com.example.alias.data.db.WordClassCount
-import com.example.alias.data.db.WordDao
-import com.example.alias.data.download.PackDownloader
-import com.example.alias.data.pack.PackParser
-import com.example.alias.data.pack.ParsedPack
 import com.example.alias.data.settings.Settings
-import com.example.alias.data.settings.SettingsRepository
-import com.example.alias.domain.DefaultGameEngine
 import com.example.alias.domain.GameEngine
-import com.example.alias.domain.MatchConfig
-import com.example.alias.domain.word.WordClassCatalog
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,28 +21,19 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.json.JSONObject
-import java.util.Locale
 import javax.inject.Inject
 import kotlin.text.Charsets
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val deckRepository: DeckRepository,
-    private val wordDao: WordDao,
-    private val deckDao: com.example.alias.data.db.DeckDao,
-    private val turnHistoryDao: com.example.alias.data.db.TurnHistoryDao,
-    private val settingsRepository: SettingsRepository,
-    private val downloader: PackDownloader,
-    private val historyRepository: TurnHistoryRepository,
+    private val deckManager: DeckManager,
+    private val settingsController: SettingsController,
+    private val gameController: GameController,
 ) : ViewModel() {
     companion object {
         private const val TAG = "MainViewModel"
@@ -80,30 +53,20 @@ class MainViewModel @Inject constructor(
     private val _deckDownloadProgress = MutableStateFlow<DeckDownloadProgress?>(null)
     val deckDownloadProgress: StateFlow<DeckDownloadProgress?> = _deckDownloadProgress.asStateFlow()
 
-    // Expose decks and enabled ids for Decks screen
-    val decks = deckRepository.getDecks()
-        .combine(settingsRepository.settings.map { it.deletedBundledDeckIds }) { allDecks, deletedIds ->
-            Log.d(TAG, "Filtering decks: allDecks=${allDecks.size}, deletedIds=${deletedIds.size}")
-            val filtered = allDecks.filter { deck ->
-                !deletedIds.contains(deck.id)
-            }
-            Log.d(TAG, "Filtered decks: ${filtered.size} (removed ${allDecks.size - filtered.size})")
-            filtered
-        }
+    val decks = deckManager.observeDecks()
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
-    val enabledDeckIds = settingsRepository.settings
-        .map { it.enabledDeckIds }
+
+    val enabledDeckIds = settingsController.enabledDeckIds
         .stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
-    val trustedSources = settingsRepository.settings
-        .map { it.trustedSources }
+
+    val trustedSources = settingsController.trustedSources
         .stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
-    val settings = settingsRepository.settings
+
+    val settings = settingsController.settings
         .stateIn(viewModelScope, SharingStarted.Lazily, Settings())
 
-    fun recentHistory(limit: Int): Flow<List<TurnHistoryEntity>> =
-        historyRepository.getRecent(limit)
+    fun recentHistory(limit: Int): Flow<List<TurnHistoryEntity>> = gameController.recentHistory(limit)
 
-    // General UI events (e.g., snackbars)
     data class UiEvent(
         val message: String,
         val actionLabel: String? = null,
@@ -112,6 +75,7 @@ class MainViewModel @Inject constructor(
         val dismissCurrent: Boolean = false,
         val onAction: (suspend () -> Unit)? = null,
     )
+
     private val _uiEvents = MutableSharedFlow<UiEvent>(
         extraBufferCapacity = 16,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
@@ -129,421 +93,44 @@ class MainViewModel @Inject constructor(
         )
     }
 
-    private data class WordQueryFilters(
-        val deckIds: List<String>,
-        val language: String,
-        val allowNSFW: Boolean,
-        val minDifficulty: Int,
-        val maxDifficulty: Int,
-        val categories: List<String>,
-        val categoryFilterEnabled: Int,
-        val wordClasses: List<String>,
-        val wordClassFilterEnabled: Int,
-    )
-
-    private data class InitialLoadResult(
-        val words: List<String>,
-        val settings: Settings,
-    )
-
-    private data class WordClassAvailabilityKey(
-        val deckIds: Set<String>,
-        val language: String,
-        val allowNSFW: Boolean,
-    )
-
-    private data class SanitizedPack(
-        val pack: ParsedPack,
-        val coverImageError: Throwable?,
-    )
-
-    private fun parseDeckIdsFromContent(content: String): List<String> {
-        return try {
-            val root = org.json.JSONObject(content)
-            val deck = root.optJSONObject("deck")
-            if (deck != null && deck.has("id")) {
-                listOf(deck.getString("id"))
-            } else {
-                emptyList()
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to parse deck IDs from content", e)
-            emptyList()
-        }
-    }
-
-    private fun canonicalizeWordClassFilters(raw: Collection<String>): List<String> {
-        val normalized = raw
-            .asSequence()
-            .mapNotNull { value ->
-                val trimmed = value.trim()
-                if (trimmed.isEmpty()) {
-                    null
-                } else {
-                    trimmed.uppercase(Locale.ROOT)
-                }
-            }
-            .toList()
-        if (normalized.isEmpty()) return emptyList()
-        val orderedKnown = WordClassCatalog.order(normalized)
-        val knownSet = orderedKnown.toSet()
-        val extras = normalized
-            .asSequence()
-            .filterNot { knownSet.contains(it) }
-            .distinct()
-            .sorted()
-            .toList()
-        return orderedKnown + extras
-    }
-
-    private suspend fun sanitizeCoverImage(pack: ParsedPack): SanitizedPack {
-        val coverError = withContext(Dispatchers.IO) {
-            pack.deck.coverImageBase64?.let { encoded ->
-                try {
-                    val decoded = Base64.decode(encoded, Base64.DEFAULT)
-                    require(decoded.isNotEmpty()) { "Cover image is empty" }
-                    val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-                    BitmapFactory.decodeByteArray(decoded, 0, decoded.size, opts)
-                    require(opts.outWidth > 0 && opts.outHeight > 0) { "Cover image has invalid dimensions" }
-                    null
-                } catch (c: CancellationException) {
-                    throw c
-                } catch (t: Throwable) {
-                    Log.e(TAG, "Failed to decode deck cover image for ${pack.deck.id}", t)
-                    t
-                }
-            }
-        }
-        val sanitized = if (coverError != null) {
-            pack.copy(deck = pack.deck.copy(coverImageBase64 = null))
-        } else {
-            pack
-        }
-        return SanitizedPack(sanitized, coverError)
-    }
-
-    private suspend fun parseAndSanitizePack(content: String, isBundledAsset: Boolean = false): SanitizedPack {
-        return try {
-            val parsed = PackParser.fromJson(content, isBundledAsset)
-            sanitizeCoverImage(parsed)
-        } catch (error: Throwable) {
-            if (error is CancellationException) throw error
-            if (!error.isCoverImageError()) throw error
-            val sanitizedJson = removeCoverImageField(content) ?: throw error
-            val parsed = PackParser.fromJson(sanitizedJson, isBundledAsset)
-            val sanitized = sanitizeCoverImage(parsed)
-            sanitized.copy(coverImageError = sanitized.coverImageError ?: error)
-        }
-    }
-
-    private fun removeCoverImageField(content: String): String? {
-        return try {
-            val root = JSONObject(content)
-            val deck = root.optJSONObject("deck") ?: return null
-            if (!deck.has("coverImage")) {
-                null
-            } else {
-                deck.remove("coverImage")
-                root.toString()
-            }
-        } catch (error: Exception) {
-            null
-        }
-    }
-
-    private fun Throwable.isCoverImageError(): Boolean {
-        if (this is IllegalArgumentException && message?.contains("cover image", ignoreCase = true) == true) {
-            return true
-        }
-        val cause = cause
-        return cause != null && cause !== this && cause.isCoverImageError()
-    }
-
-    private fun Settings.toWordQueryFilters(deckIdsOverride: Set<String>? = null): WordQueryFilters {
-        val deckIds = (deckIdsOverride ?: enabledDeckIds).toList()
-        val categories = selectedCategories.toList()
-        val classes = canonicalizeWordClassFilters(selectedWordClasses)
-        return WordQueryFilters(
-            deckIds = deckIds,
-            language = languagePreference,
-            allowNSFW = allowNSFW,
-            minDifficulty = minDifficulty,
-            maxDifficulty = maxDifficulty,
-            categories = categories,
-            categoryFilterEnabled = if (categories.isEmpty()) 0 else 1,
-            wordClasses = classes,
-            wordClassFilterEnabled = if (classes.isEmpty()) 0 else 1,
-        )
-    }
-
-    private suspend fun loadWords(filters: WordQueryFilters): List<String> {
-        if (filters.deckIds.isEmpty()) return emptyList()
-        val words = wordDao.getWordTextsForDecks(
-            filters.deckIds,
-            filters.language,
-            filters.allowNSFW,
-            filters.minDifficulty,
-            filters.maxDifficulty,
-            filters.categories,
-            filters.categoryFilterEnabled,
-            filters.wordClasses,
-            filters.wordClassFilterEnabled,
-        )
-        return words
-    }
+    private val _wordInfo = MutableStateFlow<Map<String, WordInfo>>(emptyMap())
+    val wordInfoByText: StateFlow<Map<String, WordInfo>> = _wordInfo.asStateFlow()
+    private val _availableCategories = MutableStateFlow<List<String>>(emptyList())
+    val availableCategories: StateFlow<List<String>> = _availableCategories.asStateFlow()
+    private val _availableWordClasses = MutableStateFlow<List<String>>(emptyList())
+    val availableWordClasses: StateFlow<List<String>> = _availableWordClasses.asStateFlow()
+    private val _showTutorialOnFirstTurn = MutableStateFlow(true)
+    val showTutorialOnFirstTurn: StateFlow<Boolean> = _showTutorialOnFirstTurn.asStateFlow()
 
     init {
         viewModelScope.launch {
             Log.i(TAG, "Starting MainViewModel init block")
-            val initial = withContext(Dispatchers.IO) {
-                Log.e(TAG, "Entering IO dispatcher for bundled deck import")
-                // Import bundled JSON decks from assets/decks/ when changed (by checksum) or on first run
-                val assetFiles = context.assets.list("decks")?.filter { it.endsWith(".json") } ?: emptyList()
-                Log.e(TAG, "Found ${assetFiles.size} asset files: $assetFiles")
-                val prev = settingsRepository.readBundledDeckHashes()
-                Log.e(TAG, "Previous bundled deck hashes: $prev")
-                val digest = java.security.MessageDigest.getInstance("SHA-256")
-                fun sha256(bytes: ByteArray): String = digest.digest(bytes).joinToString("") { b -> "%02x".format(b) }
-
-                // Parse deck IDs from asset files for per-deck tracking
-                val assetContents = mutableMapOf<String, String>()
-                val currentDeckEntries = mutableSetOf<String>()
-                val toImport = mutableListOf<String>()
-                val currentBundledDeckIds = mutableSetOf<String>()
-
-                for (f in assetFiles) {
-                    Log.e(TAG, "Processing asset file: $f")
-                    val content = runCatching {
-                        context.assets.open("decks/$f").bufferedReader().use { it.readText() }
-                    }.getOrNull()
-                    if (content != null) {
-                        assetContents[f] = content
-                        val bytes = content.toByteArray(Charsets.UTF_8)
-                        val fileHash = sha256(bytes)
-
-                        // Parse deck IDs from the JSON content for per-deck tracking
-                        val deckIds = parseDeckIdsFromContent(content)
-                        currentBundledDeckIds += deckIds
-
-                        // Create per-deck hash entries: "deckId:fileHash"
-                        deckIds.forEach { deckId ->
-                            val deckEntry = "$deckId:$fileHash"
-                            currentDeckEntries += deckEntry
-                        }
-
-                        // Legacy file-level tracking for backward compatibility
-                        val fileEntry = "$f:$fileHash"
-                        currentDeckEntries += fileEntry
-
-                        // Check if any deck in this file needs importing (skip user-deleted decks)
-                        val deletedBundledDeckIds = settingsRepository.readDeletedBundledDeckIds()
-                        val fileNeedsImport = prev.none { it.startsWith("$f:") } || !prev.contains(fileEntry)
-                        val decksNeedImport = deckIds.any { deckId ->
-                            val deckEntry = "$deckId:$fileHash"
-                            !deletedBundledDeckIds.contains(deckId) && (prev.none { it.startsWith("$deckId:") } || !prev.contains(deckEntry))
-                        }
-
-                        if (fileNeedsImport || decksNeedImport) {
-                            toImport += f
-                        }
-                        Log.e(TAG, "File $f has decks: $deckIds, fileHash: $fileHash, toImport: ${toImport.size} files")
-                    } else {
-                        Log.e(TAG, "Failed to read bundled deck $f")
-                    }
-                }
-
-                // Prune decks that are no longer in bundled assets (but not user-deleted ones)
-                Log.i(TAG, "Checking for decks to prune...")
-                val allDecks = deckRepository.getDecks().first()
-                Log.i(TAG, "Found ${allDecks.size} total decks in database")
-                val deletedBundledDeckIdsForPruning = settingsRepository.readDeletedBundledDeckIds()
-                Log.i(TAG, "Found ${deletedBundledDeckIdsForPruning.size} deleted bundled deck IDs: $deletedBundledDeckIdsForPruning")
-
-                // Debug: Check what settings are actually stored
-                val allSettings = settingsRepository.settings.first()
-                Log.i(TAG, "Current enabled deck IDs: ${allSettings.enabledDeckIds}")
-                Log.i(TAG, "Settings object: $allSettings")
-                val decksToPrune = allDecks.filter { deck ->
-                    deck.isOfficial && currentBundledDeckIds.contains(deck.id) && !deletedBundledDeckIdsForPruning.contains(deck.id)
-                }
-                Log.i(TAG, "Found ${decksToPrune.size} decks to prune")
-                Log.e(TAG, "Found ${decksToPrune.size} decks to prune: ${decksToPrune.map { it.id }}")
-
-                decksToPrune.forEach { deck ->
-                    try {
-                        Log.e(TAG, "Pruning removed bundled deck: ${deck.id}")
-                        deckRepository.deleteDeck(deck.id)
-                    } catch (t: Throwable) {
-                        Log.e(TAG, "Failed to prune deck ${deck.id}", t)
-                    }
-                }
-                if (prev.isEmpty() && currentDeckEntries.isEmpty()) {
-                    // No bundled content found; nothing to import
-                    Log.e(TAG, "No bundled content found")
-                } else if (prev.isEmpty() && currentDeckEntries.isNotEmpty()) {
-                    // First run: import all
-                    toImport.clear()
-                    toImport.addAll(assetFiles)
-                    Log.e(TAG, "First run: importing all ${assetFiles.size} files")
-                }
-                val hadDecks = deckRepository.getDecks().first().isNotEmpty()
-                Log.i(TAG, "Had decks before import: $hadDecks")
-                if (!hadDecks && assetFiles.isNotEmpty()) {
-                    toImport.clear()
-                    toImport.addAll(assetFiles)
-                    Log.i(TAG, "No decks found, forcing import of all files")
-                }
-                for (f in toImport) {
-                    try {
-                        Log.e(TAG, "Importing bundled deck: $f")
-                        val content = assetContents[f]
-                            ?: context.assets.open("decks/$f").bufferedReader().use { it.readText() }
-                        Log.e(TAG, "Read content for $f, length: ${content.length}")
-                        val (sanitizedPack, coverError) = parseAndSanitizePack(content, isBundledAsset = true)
-                        Log.e(TAG, "Parsed and sanitized pack for $f, coverError: ${coverError != null}")
-                        deckRepository.importPack(sanitizedPack)
-                        Log.e(TAG, "Successfully imported pack for $f")
-                        if (coverError != null) {
-                            Log.w(TAG, "Bundled deck $f cover art discarded due to decode failure", coverError)
-                        }
-                    } catch (t: Throwable) {
-                        Log.e(TAG, "Failed to import bundled deck $f", t)
-                    }
-                }
-                // Persist current checksums if any
-                runCatching {
-                    settingsRepository.writeBundledDeckHashes(currentDeckEntries)
-                    Log.i(TAG, "Persisted bundled deck hashes: $currentDeckEntries")
-                }
-                // Resolve enabled deck ids; if none set, pick available decks matching language preference
-                val baseSettings = settingsRepository.settings.first()
-                Log.e(TAG, "Base settings: ${baseSettings.enabledDeckIds.size} enabled decks")
-                val allDecksAfterImport = deckRepository.getDecks().first()
-                val deletedBundledDeckIds = settingsRepository.readDeletedBundledDeckIds()
-                Log.e(TAG, "All decks after import: ${allDecksAfterImport.size}")
-                val availableDecks = allDecksAfterImport.filter { !deletedBundledDeckIds.contains(it.id) }
-                val preferredIds = availableDecks
-                    .filter { it.language == baseSettings.languagePreference }
-                    .map { it.id }
-                    .toSet()
-                val fallbackIds = availableDecks.map { it.id }.toSet()
-                val resolvedEnabled = if (baseSettings.enabledDeckIds.isEmpty()) {
-                    if (preferredIds.isNotEmpty()) preferredIds else fallbackIds
-                } else {
-                    // Filter out any deleted bundled decks from the user's enabled list
-                    baseSettings.enabledDeckIds.filter { !deletedBundledDeckIds.contains(it) }
-                }.toSet()
-                Log.e(TAG, "Resolved enabled decks: ${resolvedEnabled.size} ids")
-                if (baseSettings.enabledDeckIds.isEmpty()) {
-                    try {
-                        settingsRepository.setEnabledDeckIds(resolvedEnabled)
-                        Log.e(TAG, "Set enabled deck ids: $resolvedEnabled")
-                    } catch (t: Throwable) {
-                        Log.e(TAG, "Failed to persist enabled deck ids", t)
-                    }
-                }
-                // Fetch words for enabled decks in preferred language
-                val filters = baseSettings.toWordQueryFilters(resolvedEnabled)
-                Log.e(TAG, "Word query filters: decks=${filters.deckIds.size}, lang=${filters.language}")
-                val words = loadWords(filters)
-                Log.e(TAG, "Loaded ${words.size} words")
-                InitialLoadResult(
-                    words = words,
-                    settings = baseSettings.copy(enabledDeckIds = resolvedEnabled),
-                )
-            }
-            Log.e(TAG, "Finished IO dispatcher, preparing word metadata")
-            // Also prepare word metadata and supporting filters for the same snapshot
-            withContext(Dispatchers.IO) {
-                val filters = initial.settings.toWordQueryFilters()
-                Log.e(TAG, "Preparing metadata for filters: decks=${filters.deckIds.size}")
-                if (filters.deckIds.isEmpty()) {
-                    _wordInfo.value = emptyMap()
-                    _availableCategories.value = emptyList()
-                    _availableWordClasses.value = emptyList()
-                    Log.e(TAG, "Empty deck ids, clearing metadata")
-                } else {
-                    coroutineScope {
-                        val briefsDeferred = async {
-                            wordDao.getWordBriefsForDecks(
-                                filters.deckIds,
-                                filters.language,
-                                filters.allowNSFW,
-                                filters.minDifficulty,
-                                filters.maxDifficulty,
-                                filters.categories,
-                                filters.categoryFilterEnabled,
-                                filters.wordClasses,
-                                filters.wordClassFilterEnabled,
-                            )
-                        }
-                        val categoriesDeferred = async {
-                            wordDao.getAvailableCategories(filters.deckIds, filters.language, filters.allowNSFW)
-                        }
-                        val classesDeferred = async {
-                            wordDao.getAvailableWordClasses(filters.deckIds, filters.language, filters.allowNSFW)
-                        }
-                        val briefs = briefsDeferred.await()
-                        val categories = categoriesDeferred.await().sorted()
-                        val classes = classesDeferred.await()
-                        Log.e(
-                            TAG,
-                            "Metadata: ${briefs.size} briefs, ${categories.size} categories, ${classes.size} classes",
-                        )
-                        val map = briefs.associateBy({ it.text }) {
-                            WordInfo(it.difficulty, it.category, parseClass(it.wordClass))
-                        }
-                        _wordInfo.value = map
-                        _availableCategories.value = categories
-                        _availableWordClasses.value = canonicalizeWordClassFilters(classes)
-                    }
-                }
-            }
-            Log.e(TAG, "Creating GameEngine with ${initial.words.size} words")
-            val e = DefaultGameEngine(initial.words, viewModelScope)
-            _engine.value = e
-            Log.e(TAG, "GameEngine created successfully")
-            val config = MatchConfig(
-                targetWords = initial.settings.targetWords,
-                maxSkips = initial.settings.maxSkips,
-                penaltyPerSkip = if (initial.settings.punishSkips) initial.settings.penaltyPerSkip else 0,
-                roundSeconds = initial.settings.roundSeconds,
-            )
-            val seed = java.security.SecureRandom().nextLong()
-            Log.e(TAG, "Starting match with config: targetWords=${config.targetWords}, maxSkips=${config.maxSkips}")
-            e.startMatch(config, teams = initial.settings.teams, seed = seed)
-            Log.e(TAG, "Match started, MainViewModel init complete")
+            val initial = deckManager.prepareInitialLoad()
+            val filters = deckManager.buildWordQueryFilters(initial.settings)
+            val metadata = deckManager.loadWordMetadata(filters)
+            _wordInfo.value = metadata.infoByWord
+            _availableCategories.value = metadata.categories
+            _availableWordClasses.value = metadata.wordClasses
+            val engineInstance = gameController.createEngine(initial.words, viewModelScope)
+            _engine.value = engineInstance
+            gameController.startMatch(engineInstance, initial.settings)
+            Log.i(TAG, "MainViewModel init complete")
         }
 
         viewModelScope.launch {
-            settingsRepository.settings
-                .map { settings ->
-                    WordClassAvailabilityKey(
-                        deckIds = settings.enabledDeckIds,
-                        language = settings.languagePreference,
-                        allowNSFW = settings.allowNSFW,
-                    )
-                }
+            settingsController.settings
+                .map { deckManager.buildWordClassAvailabilityKey(it) }
                 .distinctUntilChanged()
                 .collectLatest { key ->
-                    val ids = key.deckIds.toList()
-                    val classes = if (ids.isEmpty()) {
-                        emptyList()
-                    } else {
-                        withContext(Dispatchers.IO) {
-                            wordDao.getAvailableWordClasses(ids, key.language, key.allowNSFW)
-                        }
-                    }
-                    _availableWordClasses.value = canonicalizeWordClassFilters(classes)
+                    val classes = deckManager.loadAvailableWordClasses(key)
+                    _availableWordClasses.value = classes
                 }
         }
     }
 
     fun setDeckEnabled(id: String, enabled: Boolean, fromUndo: Boolean = false) {
         viewModelScope.launch {
-            val current = settingsRepository.settings.first().enabledDeckIds.toMutableSet()
-            if (enabled) current += id else current -= id
-            settingsRepository.setEnabledDeckIds(current)
+            deckManager.setDeckEnabled(id, enabled)
             if (!fromUndo) {
                 val msg = if (enabled) "Enabled deck: $id" else "Disabled deck: $id"
                 _uiEvents.tryEmit(
@@ -558,100 +145,44 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun deleteDeck(deck: DeckEntity) {
+    fun setAllDecksEnabled(enableAll: Boolean) {
         viewModelScope.launch {
-            val id = deck.id
-            val settingsSnapshot = settingsRepository.settings.first()
-            val updatedIds = settingsSnapshot.enabledDeckIds - id
-
-            // Check if this is a bundled deck (official deck)
-            val isBundledDeck = deck.isOfficial
-            Log.i(TAG, "Deleting deck: ${deck.name} (ID: $id, isOfficial: $isBundledDeck)")
-
-            val result = runCatching {
-                withContext(Dispatchers.IO) {
-                    if (isBundledDeck) {
-                        // For bundled decks, mark as deleted instead of actually deleting
-                        Log.i(TAG, "Marking bundled deck as deleted: $id")
-                        settingsRepository.addDeletedBundledDeckId(id)
-                        // Remove from enabled decks
-                        settingsRepository.setEnabledDeckIds(updatedIds)
-                        Log.i(TAG, "Successfully marked bundled deck as deleted: $id")
-                    } else {
-                        // For user-imported decks, actually delete them
-                        Log.i(TAG, "Actually deleting user-imported deck: $id")
-                        deckRepository.deleteDeck(id)
-                    }
-                }
-            }
-            if (result.isFailure) {
-                val error = result.exceptionOrNull()?.message ?: "Unknown error"
-                _uiEvents.tryEmit(
-                    UiEvent(
-                        message = "Failed to delete deck: $error",
-                        actionLabel = "Dismiss",
-                        duration = SnackbarDuration.Long,
-                        isError = true,
-                        dismissCurrent = true,
-                    ),
-                )
-                return@launch
-            }
-            if (updatedIds != settingsSnapshot.enabledDeckIds) {
-                settingsRepository.setEnabledDeckIds(updatedIds)
-            }
-            val actionMessage = if (isBundledDeck) "Hidden deck: ${deck.name}" else "Deleted deck: ${deck.name}"
-            _uiEvents.tryEmit(
-                UiEvent(
-                    message = actionMessage,
-                    actionLabel = "OK",
-                    dismissCurrent = true,
-                ),
-            )
+            deckManager.setAllDecksEnabled(enableAll)
+            val msg = if (enableAll) "Enabled all decks" else "Disabled all decks"
+            _uiEvents.tryEmit(UiEvent(message = msg, actionLabel = "OK"))
         }
     }
 
-    fun restoreDeletedBundledDeck(deckId: String) {
+    fun deleteDeck(deck: DeckEntity) {
         viewModelScope.launch {
-            Log.i(TAG, "Restoring deleted bundled deck: $deckId")
-            val result = runCatching {
-                withContext(Dispatchers.IO) {
-                    settingsRepository.removeDeletedBundledDeckId(deckId)
+            when (val result = deckManager.deleteDeck(deck)) {
+                is DeckManager.DeleteDeckResult.Success -> {
+                    _uiEvents.tryEmit(
+                        UiEvent(
+                            message = result.message,
+                            actionLabel = "OK",
+                            dismissCurrent = true,
+                        ),
+                    )
+                }
+                is DeckManager.DeleteDeckResult.Failure -> {
+                    _uiEvents.tryEmit(
+                        UiEvent(
+                            message = "Failed to delete deck: ${result.errorMessage}",
+                            actionLabel = "Dismiss",
+                            duration = SnackbarDuration.Long,
+                            isError = true,
+                            dismissCurrent = true,
+                        ),
+                    )
                 }
             }
-            if (result.isFailure) {
-                val error = result.exceptionOrNull()?.message ?: "Unknown error"
-                _uiEvents.tryEmit(
-                    UiEvent(
-                        message = "Failed to restore deck: $error",
-                        actionLabel = "Dismiss",
-                        duration = SnackbarDuration.Long,
-                        isError = true,
-                        dismissCurrent = true,
-                    ),
-                )
-                return@launch
-            }
-            _uiEvents.tryEmit(
-                UiEvent(
-                    message = "Restored deck",
-                    actionLabel = "OK",
-                    dismissCurrent = true,
-                ),
-            )
         }
     }
 
     fun permanentlyDeleteImportedDeck(deck: DeckEntity) {
         viewModelScope.launch {
-            val id = deck.id
-            Log.i(TAG, "Permanently deleting imported deck: $id")
-
-            val result = runCatching {
-                withContext(Dispatchers.IO) {
-                    deckRepository.deleteDeck(id)
-                }
-            }
+            val result = deckManager.permanentlyDeleteImportedDeck(deck)
             if (result.isFailure) {
                 val error = result.exceptionOrNull()?.message ?: "Unknown error"
                 _uiEvents.tryEmit(
@@ -675,98 +206,87 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun setAllDecksEnabled(enableAll: Boolean) {
+    fun restoreDeletedBundledDeck(deckId: String) {
         viewModelScope.launch {
-            val all = deckRepository.getDecks().first().map { it.id }.toSet()
-            val target = if (enableAll) all else emptySet()
-            settingsRepository.setEnabledDeckIds(target)
-            val msg = if (enableAll) "Enabled all decks" else "Disabled all decks"
-            _uiEvents.tryEmit(UiEvent(message = msg, actionLabel = "OK"))
+            val result = deckManager.restoreDeletedBundledDeck(deckId)
+            if (result.isFailure) {
+                val error = result.exceptionOrNull()?.message ?: "Unknown error"
+                _uiEvents.tryEmit(
+                    UiEvent(
+                        message = "Failed to restore deck: $error",
+                        actionLabel = "Dismiss",
+                        duration = SnackbarDuration.Long,
+                        isError = true,
+                        dismissCurrent = true,
+                    ),
+                )
+                return@launch
+            }
+            _uiEvents.tryEmit(
+                UiEvent(
+                    message = "Restored deck",
+                    actionLabel = "OK",
+                    dismissCurrent = true,
+                ),
+            )
         }
     }
 
     fun addTrustedSource(originOrHost: String) {
         viewModelScope.launch {
-            val input = originOrHost.trim().lowercase()
-            val normalized = when {
-                input.startsWith("https://") -> input.removeSuffix("/")
-                "://" in input -> null // reject non-https schemes
-                else -> input // bare host
+            when (settingsController.addTrustedSource(originOrHost)) {
+                SettingsController.TrustedSourceResult.Invalid -> {
+                    _uiEvents.tryEmit(
+                        UiEvent(
+                            message = "Invalid host/origin",
+                            actionLabel = "Dismiss",
+                            duration = SnackbarDuration.Short,
+                            isError = true,
+                        ),
+                    )
+                }
+                is SettingsController.TrustedSourceResult.Added,
+                is SettingsController.TrustedSourceResult.Unchanged,
+                -> Unit
             }
-            if (normalized.isNullOrBlank()) {
-                _uiEvents.tryEmit(
-                    UiEvent(
-                        message = "Invalid host/origin",
-                        actionLabel = "Dismiss",
-                        duration = SnackbarDuration.Short,
-                        isError = true,
-                    ),
-                )
-                return@launch
-            }
-            val cur = settingsRepository.settings.first().trustedSources.toMutableSet()
-            cur += normalized
-            settingsRepository.setTrustedSources(cur)
         }
     }
 
     fun updateDifficultyFilter(min: Int, max: Int) {
-        viewModelScope.launch {
-            settingsRepository.updateDifficultyFilter(min, max)
-        }
+        viewModelScope.launch { settingsController.updateDifficultyFilter(min, max) }
     }
 
     fun updateCategoriesFilter(categories: Set<String>) {
-        viewModelScope.launch {
-            settingsRepository.setCategoriesFilter(categories)
-        }
+        viewModelScope.launch { settingsController.updateCategoriesFilter(categories) }
     }
 
     fun updateWordClassesFilter(classes: Set<String>) {
-        viewModelScope.launch {
-            settingsRepository.setWordClassesFilter(classes)
-        }
+        viewModelScope.launch { settingsController.updateWordClassesFilter(classes) }
     }
 
     fun removeTrustedSource(entry: String) {
-        viewModelScope.launch {
-            val cur = settingsRepository.settings.first().trustedSources.toMutableSet()
-            cur -= entry
-            settingsRepository.setTrustedSources(cur)
-        }
+        viewModelScope.launch { settingsController.removeTrustedSource(entry) }
     }
 
-    suspend fun getWordCount(deckId: String): Int = deckRepository.getWordCount(deckId)
+    suspend fun getWordCount(deckId: String): Int = deckManager.getWordCount(deckId)
 
-    suspend fun getDeckCategories(deckId: String): List<String> = withContext(Dispatchers.IO) {
-        wordDao.getDeckCategories(deckId)
-    }
+    suspend fun getDeckCategories(deckId: String): List<String> = deckManager.getDeckCategories(deckId)
 
-    suspend fun getDeckWordSamples(deckId: String, limit: Int = 5): List<String> = withContext(Dispatchers.IO) {
-        wordDao.getRandomWordSamples(deckId, limit)
-    }
+    suspend fun getDeckWordSamples(deckId: String, limit: Int = 5): List<String> =
+        deckManager.getDeckWordSamples(deckId, limit)
 
     suspend fun getDeckDifficultyHistogram(deckId: String): List<DifficultyBucket> =
-        withContext(Dispatchers.IO) { deckRepository.getDifficultyHistogram(deckId) }
+        deckManager.getDeckDifficultyHistogram(deckId)
 
     suspend fun getDeckRecentWords(deckId: String, limit: Int = 8): List<String> =
-        withContext(Dispatchers.IO) { deckRepository.getRecentWords(deckId, limit) }
+        deckManager.getDeckRecentWords(deckId, limit)
 
     suspend fun getDeckWordClassCounts(deckId: String): List<WordClassCount> =
-        withContext(Dispatchers.IO) {
-            val counts = wordDao.getWordClassCounts(deckId)
-            val knownOrder = WordClassCatalog.allowed.withIndex().associate { it.value to it.index }
-            counts.sortedWith(
-                compareBy(
-                    { knownOrder[it.wordClass] ?: Int.MAX_VALUE },
-                    { it.wordClass },
-                ),
-            )
-        }
+        deckManager.getDeckWordClassCounts(deckId)
 
     fun updateSeenTutorial(value: Boolean) {
         viewModelScope.launch {
-            settingsRepository.updateSeenTutorial(value)
+            settingsController.updateSeenTutorial(value)
             _showTutorialOnFirstTurn.value = false
         }
     }
@@ -786,28 +306,21 @@ class MainViewModel @Inject constructor(
                 ),
             )
             try {
-                val bytes = withContext(Dispatchers.IO) {
-                    var lastUpdate = 0L
-                    downloader.download(
-                        url.trim(),
-                        expectedSha256?.trim().takeUnless { it.isNullOrEmpty() },
-                    ) { bytesRead, totalBytes ->
-                        val now = System.currentTimeMillis()
-                        if (now - lastUpdate > 100 || (totalBytes != null && bytesRead == totalBytes)) {
-                            _deckDownloadProgress.value = DeckDownloadProgress(
-                                step = DeckDownloadStep.DOWNLOADING,
-                                bytesRead = bytesRead,
-                                totalBytes = totalBytes,
-                            )
-                            lastUpdate = now
-                        }
+                var lastUpdate = 0L
+                val bytes = deckManager.downloadPack(url, expectedSha256) { bytesRead, totalBytes ->
+                    val now = System.currentTimeMillis()
+                    if (now - lastUpdate > 100 || (totalBytes != null && bytesRead == totalBytes)) {
+                        _deckDownloadProgress.value = DeckDownloadProgress(
+                            step = DeckDownloadStep.DOWNLOADING,
+                            bytesRead = bytesRead,
+                            totalBytes = totalBytes,
+                        )
+                        lastUpdate = now
                     }
                 }
-                // Try JSON first
-                val text = bytes.toString(Charsets.UTF_8)
                 _deckDownloadProgress.value = DeckDownloadProgress(step = DeckDownloadStep.IMPORTING)
-                val (sanitizedPack, imageError) = withContext(Dispatchers.IO) { parseAndSanitizePack(text) }
-                withContext(Dispatchers.IO) { deckRepository.importPack(sanitizedPack) }
+                val text = bytes.toString(Charsets.UTF_8)
+                val result = deckManager.importPackFromJson(text)
                 _uiEvents.tryEmit(
                     UiEvent(
                         message = "Imported deck from URL",
@@ -816,7 +329,7 @@ class MainViewModel @Inject constructor(
                         dismissCurrent = true,
                     ),
                 )
-                if (imageError != null) {
+                if (result.coverImageError != null) {
                     showCoverImageErrorSnackbar()
                 }
             } catch (t: Throwable) {
@@ -838,25 +351,20 @@ class MainViewModel @Inject constructor(
     fun importDeckFromFile(uri: Uri) {
         viewModelScope.launch {
             try {
-                val text = withContext(Dispatchers.IO) {
-                    context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
-                        ?: throw IllegalStateException("Empty file")
-                }
-                val (sanitizedPack, imageError) = withContext(Dispatchers.IO) { parseAndSanitizePack(text) }
-                withContext(Dispatchers.IO) { deckRepository.importPack(sanitizedPack) }
+                val result = deckManager.importDeckFromUri(uri)
                 runCatching {
-                    val s = settingsRepository.settings.first()
-                    if (sanitizedPack.deck.language == s.languagePreference) {
+                    val s = settingsController.settings.first()
+                    if (result.language.equals(s.languagePreference, ignoreCase = true)) {
                         val ids = s.enabledDeckIds.toMutableSet()
-                        if (ids.add(sanitizedPack.deck.id)) {
-                            settingsRepository.setEnabledDeckIds(ids)
+                        if (ids.add(result.deckId)) {
+                            settingsController.setEnabledDeckIds(ids)
                         }
                     }
                 }
                 _uiEvents.tryEmit(
                     UiEvent(message = "Imported deck", actionLabel = "OK", duration = SnackbarDuration.Short),
                 )
-                if (imageError != null) {
+                if (result.coverImageError != null) {
                     showCoverImageErrorSnackbar()
                 }
             } catch (t: Throwable) {
@@ -873,85 +381,31 @@ class MainViewModel @Inject constructor(
     }
 
     suspend fun updateSettings(request: SettingsUpdateRequest) {
-        // Persist all settings synchronously so callers can chain actions reliably (e.g., Save & Restart)
-        val before = settingsRepository.settings.first()
-        settingsRepository.updateRoundSeconds(request.roundSeconds)
-        settingsRepository.updateTargetWords(request.targetWords)
-        settingsRepository.updateSkipPolicy(request.maxSkips, request.penaltyPerSkip)
-        settingsRepository.updatePunishSkips(request.punishSkips)
-        settingsRepository.updateAllowNSFW(request.allowNSFW)
-        settingsRepository.updateHapticsEnabled(request.haptics)
-        settingsRepository.updateSoundEnabled(request.sound)
-        settingsRepository.updateOneHandedLayout(request.oneHanded)
-        settingsRepository.updateVerticalSwipes(request.verticalSwipes)
-        settingsRepository.updateOrientation(request.orientation)
-        settingsRepository.updateUiLanguage(canonicalizeLocalePreference(request.uiLanguage))
-        // Language validation may fail; keep others applied regardless
-        val langResult = runCatching { settingsRepository.updateLanguagePreference(request.language) }
-        langResult.onFailure { error ->
+        val result = settingsController.applySettingsUpdate(request)
+        result.languageErrorMessage?.let { error ->
             _uiEvents.tryEmit(
                 UiEvent(
-                    message = error.message ?: "Invalid language",
+                    message = error,
                     duration = SnackbarDuration.Short,
                     isError = true,
                 ),
             )
         }
-        langResult.onSuccess {
-            val newLang = request.language.trim().lowercase()
-            val languageUnchanged = newLang.equals(before.languagePreference, ignoreCase = true)
-            if (languageUnchanged) return@onSuccess
-
-            val preferredDeckIds = deckRepository
-                .getDecks()
-                .first()
-                .filter { it.language.equals(newLang, ignoreCase = true) }
-                .map { it.id }
-                .toSet()
-            val preferredDecksChanged = preferredDeckIds.isNotEmpty() && preferredDeckIds != before.enabledDeckIds
-            if (!preferredDecksChanged) return@onSuccess
-
-            settingsRepository.setEnabledDeckIds(preferredDeckIds)
+        result.languageChange?.let { change ->
             _uiEvents.tryEmit(
                 UiEvent(
-                    message = "Enabled ${preferredDeckIds.size} deck(s) for $newLang",
+                    message = "Enabled ${change.newDeckIds.size} deck(s) for ${change.language}",
                     actionLabel = "Undo",
-                    onAction = { settingsRepository.setEnabledDeckIds(before.enabledDeckIds) },
+                    onAction = { settingsController.setEnabledDeckIds(change.previousDeckIds) },
                 ),
             )
         }
-        // Ensure teams are saved
-        settingsRepository.setTeams(request.teams)
         _uiEvents.tryEmit(UiEvent(message = "Settings updated", actionLabel = "Dismiss"))
-    }
-
-    data class WordInfo(val difficulty: Int, val category: String?, val wordClass: String?)
-    private val _wordInfo = MutableStateFlow<Map<String, WordInfo>>(emptyMap())
-    val wordInfoByText: StateFlow<Map<String, WordInfo>> = _wordInfo.asStateFlow()
-    private val _availableCategories = MutableStateFlow<List<String>>(emptyList())
-    val availableCategories: StateFlow<List<String>> = _availableCategories.asStateFlow()
-    private val _availableWordClasses = MutableStateFlow<List<String>>(emptyList())
-    val availableWordClasses: StateFlow<List<String>> = _availableWordClasses.asStateFlow()
-    private val _showTutorialOnFirstTurn = MutableStateFlow(true)
-    val showTutorialOnFirstTurn: StateFlow<Boolean> = _showTutorialOnFirstTurn.asStateFlow()
-
-    private fun parseClass(raw: String?): String? {
-        return raw
-            ?.split(',')
-            ?.asSequence()
-            ?.mapNotNull { WordClassCatalog.normalizeOrNull(it) }
-            ?.firstOrNull()
     }
 
     fun resetLocalData(onDone: (() -> Unit)? = null) {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                // Clear DB tables
-                turnHistoryDao.deleteAll()
-                deckDao.deleteAll() // cascades to words via FK
-                // Clear preferences
-                settingsRepository.clearAll()
-            }
+            deckManager.resetLocalData()
             _uiEvents.tryEmit(UiEvent(message = "Local data cleared", actionLabel = "OK"))
             onDone?.invoke()
         }
@@ -959,107 +413,36 @@ class MainViewModel @Inject constructor(
 
     fun restartMatch() {
         viewModelScope.launch {
-            val s = settingsRepository.settings.first()
-            val filters = s.toWordQueryFilters()
-            val words = withContext(Dispatchers.IO) { loadWords(filters) }
-            // Update word info cache for current filters
-            viewModelScope.launch(Dispatchers.IO) {
-                val briefs = if (filters.deckIds.isEmpty()) {
-                    emptyList()
-                } else {
-                    wordDao.getWordBriefsForDecks(
-                        filters.deckIds,
-                        filters.language,
-                        filters.allowNSFW,
-                        filters.minDifficulty,
-                        filters.maxDifficulty,
-                        filters.categories,
-                        filters.categoryFilterEnabled,
-                        filters.wordClasses,
-                        filters.wordClassFilterEnabled,
-                    )
-                }
-                val map = briefs.associateBy({ it.text }) {
-                    WordInfo(it.difficulty, it.category, parseClass(it.wordClass))
-                }
-                _wordInfo.value = map
-            }
-            // Update available categories
-            viewModelScope.launch(Dispatchers.IO) {
-                val list = if (filters.deckIds.isEmpty()) {
-                    emptyList()
-                } else {
-                    wordDao.getAvailableCategories(
-                        filters.deckIds,
-                        filters.language,
-                        filters.allowNSFW,
-                    ).sorted()
-                }
-                _availableCategories.value = list
-            }
-            // Update available word classes
-            viewModelScope.launch(Dispatchers.IO) {
-                val list = if (filters.deckIds.isEmpty()) {
-                    emptyList()
-                } else {
-                    wordDao.getAvailableWordClasses(
-                        filters.deckIds,
-                        filters.language,
-                        filters.allowNSFW,
-                    )
-                }
-                _availableWordClasses.value = canonicalizeWordClassFilters(list)
-            }
-            val e = DefaultGameEngine(words, viewModelScope)
-            _engine.value = e
-            val config = MatchConfig(
-                targetWords = s.targetWords,
-                maxSkips = s.maxSkips,
-                penaltyPerSkip = if (s.punishSkips) s.penaltyPerSkip else 0,
-                roundSeconds = s.roundSeconds,
-            )
-            val seed = java.security.SecureRandom().nextLong()
-            e.startMatch(config, teams = s.teams, seed = seed)
+            val currentSettings = settingsController.settings.first()
+            val filters = deckManager.buildWordQueryFilters(currentSettings)
+            val words = deckManager.loadWords(filters)
+            val metadata = deckManager.loadWordMetadata(filters)
+            _wordInfo.value = metadata.infoByWord
+            _availableCategories.value = metadata.categories
+            _availableWordClasses.value = metadata.wordClasses
+            val engineInstance = gameController.createEngine(words, viewModelScope)
+            _engine.value = engineInstance
+            gameController.startMatch(engineInstance, currentSettings)
             _uiEvents.tryEmit(UiEvent(message = "Match restarted", actionLabel = "Dismiss"))
         }
     }
 
     fun nextTurn() {
         val e = _engine.value ?: return
-        val current = e.state.value
-        if (current is com.example.alias.domain.GameState.TurnFinished) {
-            viewModelScope.launch {
-                val infoByWord = _wordInfo.value
-                val entries = current.outcomes.map {
-                    com.example.alias.data.db.TurnHistoryEntity(
-                        0L,
-                        current.team,
-                        it.word,
-                        it.correct,
-                        it.skipped,
-                        infoByWord[it.word]?.difficulty,
-                        it.timestamp,
-                    )
-                }
-                historyRepository.save(entries)
-                e.nextTurn()
-            }
-        }
+        viewModelScope.launch { gameController.completeTurn(e, _wordInfo.value) }
     }
 
     fun startTurn() {
         val e = _engine.value ?: return
-        viewModelScope.launch { e.startTurn() }
+        viewModelScope.launch { gameController.startTurn(e) }
     }
 
     fun overrideOutcome(index: Int, correct: Boolean) {
         val e = _engine.value ?: return
-        viewModelScope.launch { e.overrideOutcome(index, correct) }
+        viewModelScope.launch { gameController.overrideOutcome(e, index, correct) }
     }
 
     fun setOrientation(value: String) {
-        viewModelScope.launch {
-            settingsRepository.updateOrientation(value)
-        }
+        viewModelScope.launch { settingsController.setOrientation(value) }
     }
 }

--- a/app/src/main/java/com/example/alias/SettingsController.kt
+++ b/app/src/main/java/com/example/alias/SettingsController.kt
@@ -1,0 +1,135 @@
+package com.example.alias
+
+import com.example.alias.data.DeckRepository
+import com.example.alias.data.db.DeckEntity
+import com.example.alias.data.settings.Settings
+import com.example.alias.data.settings.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SettingsController @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+    private val deckRepository: DeckRepository,
+) {
+    val settings: Flow<Settings> = settingsRepository.settings
+
+    val enabledDeckIds: Flow<Set<String>> = settings.map { it.enabledDeckIds }
+
+    val trustedSources: Flow<Set<String>> = settings.map { it.trustedSources }
+
+    suspend fun addTrustedSource(originOrHost: String): TrustedSourceResult {
+        val input = originOrHost.trim().lowercase()
+        val normalized = when {
+            input.startsWith("https://") -> input.removeSuffix("/")
+            "://" in input -> null
+            else -> input
+        }
+        if (normalized.isNullOrBlank()) {
+            return TrustedSourceResult.Invalid
+        }
+        val current = settingsRepository.settings.first().trustedSources.toMutableSet()
+        val changed = current.add(normalized)
+        if (!changed) {
+            return TrustedSourceResult.Unchanged(normalized)
+        }
+        settingsRepository.setTrustedSources(current)
+        return TrustedSourceResult.Added(normalized)
+    }
+
+    suspend fun removeTrustedSource(entry: String) {
+        val current = settingsRepository.settings.first().trustedSources.toMutableSet()
+        current -= entry
+        settingsRepository.setTrustedSources(current)
+    }
+
+    suspend fun updateDifficultyFilter(min: Int, max: Int) {
+        settingsRepository.updateDifficultyFilter(min, max)
+    }
+
+    suspend fun updateCategoriesFilter(categories: Set<String>) {
+        settingsRepository.setCategoriesFilter(categories)
+    }
+
+    suspend fun updateWordClassesFilter(classes: Set<String>) {
+        settingsRepository.setWordClassesFilter(classes)
+    }
+
+    suspend fun updateSeenTutorial(value: Boolean) {
+        settingsRepository.updateSeenTutorial(value)
+    }
+
+    suspend fun applySettingsUpdate(request: SettingsUpdateRequest): UpdateResult {
+        val before = settingsRepository.settings.first()
+        settingsRepository.updateRoundSeconds(request.roundSeconds)
+        settingsRepository.updateTargetWords(request.targetWords)
+        settingsRepository.updateSkipPolicy(request.maxSkips, request.penaltyPerSkip)
+        settingsRepository.updatePunishSkips(request.punishSkips)
+        settingsRepository.updateAllowNSFW(request.allowNSFW)
+        settingsRepository.updateHapticsEnabled(request.haptics)
+        settingsRepository.updateSoundEnabled(request.sound)
+        settingsRepository.updateOneHandedLayout(request.oneHanded)
+        settingsRepository.updateVerticalSwipes(request.verticalSwipes)
+        settingsRepository.updateOrientation(request.orientation)
+        settingsRepository.updateUiLanguage(canonicalizeLocalePreference(request.uiLanguage))
+
+        val languageResult = runCatching { settingsRepository.updateLanguagePreference(request.language) }
+        var languageError: String? = null
+        var languageChange: LanguageChange? = null
+        languageResult.onFailure { error ->
+            languageError = error.message ?: "Invalid language"
+        }
+        languageResult.onSuccess {
+            val newLang = request.language.trim().lowercase()
+            val languageUnchanged = newLang.equals(before.languagePreference, ignoreCase = true)
+            if (!languageUnchanged) {
+                val preferredDeckIds = withContext(Dispatchers.IO) {
+                    deckRepository
+                        .getDecks()
+                        .first()
+                        .filter { it.language.equals(newLang, ignoreCase = true) }
+                        .map(DeckEntity::id)
+                        .toSet()
+                }
+                val preferredDecksChanged = preferredDeckIds.isNotEmpty() && preferredDeckIds != before.enabledDeckIds
+                if (preferredDecksChanged) {
+                    settingsRepository.setEnabledDeckIds(preferredDeckIds)
+                    languageChange = LanguageChange(newLang, preferredDeckIds, before.enabledDeckIds)
+                }
+            }
+        }
+
+        settingsRepository.setTeams(request.teams)
+        return UpdateResult(languageErrorMessage = languageError, languageChange = languageChange)
+    }
+
+    suspend fun setEnabledDeckIds(ids: Set<String>) {
+        settingsRepository.setEnabledDeckIds(ids)
+    }
+
+    suspend fun setOrientation(value: String) {
+        settingsRepository.updateOrientation(value)
+    }
+
+    sealed interface TrustedSourceResult {
+        data object Invalid : TrustedSourceResult
+        data class Added(val normalized: String) : TrustedSourceResult
+        data class Unchanged(val normalized: String) : TrustedSourceResult
+    }
+
+    data class UpdateResult(
+        val languageErrorMessage: String? = null,
+        val languageChange: LanguageChange? = null,
+    )
+
+    data class LanguageChange(
+        val language: String,
+        val newDeckIds: Set<String>,
+        val previousDeckIds: Set<String>,
+    )
+}

--- a/app/src/main/java/com/example/alias/WordInfo.kt
+++ b/app/src/main/java/com/example/alias/WordInfo.kt
@@ -1,0 +1,15 @@
+package com.example.alias
+
+/** Metadata associated with a single word surfaced to the UI. */
+data class WordInfo(
+    val difficulty: Int,
+    val category: String?,
+    val wordClass: String?,
+)
+
+/** Aggregated metadata describing the available word set for active filters. */
+data class WordMetadata(
+    val infoByWord: Map<String, WordInfo>,
+    val categories: List<String>,
+    val wordClasses: List<String>,
+)

--- a/app/src/main/java/com/example/alias/ui/AppScaffold.kt
+++ b/app/src/main/java/com/example/alias/ui/AppScaffold.kt
@@ -36,4 +36,3 @@ fun appScaffold(
 
 private fun String.isErrorSnackbarMessage(): Boolean =
     startsWith("Failed", ignoreCase = true) || contains("error", ignoreCase = true)
-

--- a/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
@@ -281,7 +281,7 @@ fun decksScreen(vm: MainViewModel, onDeckSelected: (DeckEntity) -> Unit) {
                 },
             )
         }
-    
+
         val deckToPermanentlyDelete = deckPendingPermanentDelete
         if (deckToPermanentlyDelete != null) {
             AlertDialog(
@@ -357,7 +357,7 @@ private fun decksHeroSummary(state: DecksHeroSummaryState, actions: DecksHeroSum
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                ) {
+            ) {
                 deckLanguagesSummary(languages = languages)
                 FilledTonalButton(onClick = actions.onFiltersClick) {
                     Icon(Icons.Filled.Tune, contentDescription = null)
@@ -924,19 +924,19 @@ private fun deckDeletedDecksSheet(
     ) {
         Text(
             text = "Deleted Decks",
-            style = MaterialTheme.typography.titleLarge
+            style = MaterialTheme.typography.titleLarge,
         )
 
         if (deletedBundledDeckIds.isEmpty()) {
             Text(
                 text = "No deleted decks",
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } else {
             Text(
                 text = "Deleted Bundled Decks (tap to restore):",
-                style = MaterialTheme.typography.titleMedium
+                style = MaterialTheme.typography.titleMedium,
             )
 
             deletedBundledDeckIds.forEach { deckId ->
@@ -960,7 +960,7 @@ private fun deckDeletedDecksSheet(
             Text(
                 text = "Note: Imported decks that are deleted are permanently removed and cannot be restored.",
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/app/src/main/java/com/example/alias/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/home/HomeScreen.kt
@@ -30,9 +30,7 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
@@ -40,7 +38,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
@@ -94,7 +91,7 @@ fun homeScreen(
         Row(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal=24.dp, vertical=4.dp)
+                .padding(horizontal = 24.dp, vertical = 4.dp)
                 .verticalScroll(scrollState),
             horizontalArrangement = Arrangement.spacedBy(20.dp),
             verticalAlignment = Alignment.Top,
@@ -116,7 +113,7 @@ fun homeScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal=24.dp, vertical=12.dp)
+                .padding(horizontal = 24.dp, vertical = 12.dp)
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -126,7 +123,6 @@ fun homeScreen(
         }
     }
 }
-
 
 @Composable
 private fun ColumnScope.navigationActionCards(actions: HomeActions) {
@@ -295,7 +291,7 @@ private fun homeHeroSection(
                         Text(
                             heroTitle,
                             style = if (isLandscape) MaterialTheme.typography.titleLarge else MaterialTheme.typography.headlineSmall,
-                            color = contentColor
+                            color = contentColor,
                         )
                         Text(
                             heroSubtitle,
@@ -484,7 +480,9 @@ private fun recentHighlightSection(
                         modifier = Modifier.size(18.dp),
                     )
                 }
-            } else null,
+            } else {
+                null
+            },
             colors = AssistChipDefaults.assistChipColors(
                 containerColor = contentColor.copy(alpha = 0.08f),
                 labelColor = contentColor,
@@ -578,4 +576,3 @@ private val ScoreboardSaver: Saver<SnapshotStateMap<String, Int>, Bundle> = Save
         }
     },
 )
-

--- a/app/src/test/java/com/example/alias/DeckManagerTest.kt
+++ b/app/src/test/java/com/example/alias/DeckManagerTest.kt
@@ -1,0 +1,229 @@
+package com.example.alias
+
+import android.app.Application
+import android.content.Context
+import com.example.alias.data.DeckRepository
+import com.example.alias.data.db.DeckDao
+import com.example.alias.data.db.DeckEntity
+import com.example.alias.data.db.DifficultyBucket
+import com.example.alias.data.db.TurnHistoryDao
+import com.example.alias.data.db.WordBrief
+import com.example.alias.data.db.WordClassCount
+import com.example.alias.data.db.WordDao
+import com.example.alias.data.download.PackDownloader
+import com.example.alias.data.pack.ParsedPack
+import com.example.alias.data.settings.Settings
+import com.example.alias.data.settings.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class DeckManagerTest {
+    private lateinit var context: Context
+    private lateinit var deckManager: DeckManager
+    private lateinit var settingsRepository: FakeSettingsRepository
+    private lateinit var wordDao: FakeWordDao
+
+    @Before
+    fun setUp() {
+        context = Application()
+        settingsRepository = FakeSettingsRepository()
+        wordDao = FakeWordDao()
+        deckManager = DeckManager(
+            context = context,
+            deckRepository = FakeDeckRepository(),
+            wordDao = wordDao,
+            deckDao = FakeDeckDao(),
+            turnHistoryDao = FakeTurnHistoryDao(),
+            settingsRepository = settingsRepository,
+            downloader = PackDownloader(OkHttpClient(), settingsRepository),
+        )
+    }
+
+    @Test
+    fun canonicalizeWordClassFiltersOrdersKnownValues() {
+        val result = deckManager.canonicalizeWordClassFilters(listOf("verb", "unknown", "Adj", "adj"))
+        assertEquals(listOf("ADJ", "VERB", "UNKNOWN"), result)
+    }
+
+    @Test
+    fun parsePrimaryWordClassReturnsFirstNormalizedEntry() {
+        val parsed = deckManager.parsePrimaryWordClass(" foo , adj, verb")
+        assertEquals("ADJ", parsed)
+    }
+
+    @Test
+    fun loadAvailableWordClassesCanonicalizesValues() = runBlocking {
+        wordDao.availableWordClasses = listOf("verb", "unknown", "Adj")
+        val key = DeckManager.WordClassAvailabilityKey(setOf("deck"), language = "en", allowNSFW = false)
+
+        val classes = deckManager.loadAvailableWordClasses(key)
+
+        assertEquals(listOf("ADJ", "VERB", "UNKNOWN"), classes)
+    }
+
+    @Test
+    fun buildWordQueryFiltersSetsFlagsBasedOnSelections() {
+        val settings = Settings(
+            enabledDeckIds = setOf("a", "b"),
+            selectedCategories = setOf("party"),
+            selectedWordClasses = setOf("verb"),
+            allowNSFW = true,
+            minDifficulty = 2,
+            maxDifficulty = 4,
+        )
+
+        val filters = deckManager.buildWordQueryFilters(settings)
+
+        assertEquals(listOf("a", "b"), filters.deckIds)
+        assertEquals(1, filters.categoryFilterEnabled)
+        assertEquals(1, filters.wordClassFilterEnabled)
+        assertEquals(listOf("VERB"), filters.wordClasses)
+    }
+
+    private class FakeDeckRepository : DeckRepository {
+        override fun getDecks(): Flow<List<DeckEntity>> = MutableStateFlow(emptyList())
+        override suspend fun getWordCount(deckId: String): Int = throw UnsupportedOperationException()
+        override suspend fun getDifficultyHistogram(deckId: String): List<DifficultyBucket> = throw UnsupportedOperationException()
+        override suspend fun getRecentWords(deckId: String, limit: Int): List<String> = throw UnsupportedOperationException()
+        override suspend fun importJson(content: String) = throw UnsupportedOperationException()
+        override suspend fun importPack(pack: ParsedPack) = throw UnsupportedOperationException()
+        override suspend fun deleteDeck(deckId: String) = throw UnsupportedOperationException()
+    }
+
+    private class FakeWordDao : WordDao {
+        var availableWordClasses: List<String> = emptyList()
+
+        override suspend fun insertWords(words: List<com.example.alias.data.db.WordEntity>) = throw UnsupportedOperationException()
+        override suspend fun insertWordClasses(entries: List<com.example.alias.data.db.WordClassEntity>) = throw UnsupportedOperationException()
+        override suspend fun getWordTexts(deckId: String): List<String> = throw UnsupportedOperationException()
+        override suspend fun getWordCount(deckId: String): Int = throw UnsupportedOperationException()
+        override suspend fun deleteByDeck(deckId: String) = throw UnsupportedOperationException()
+        override suspend fun getWordTextsForDecks(
+            deckIds: List<String>,
+            language: String,
+            allowNSFW: Boolean,
+            minDifficulty: Int,
+            maxDifficulty: Int,
+            categories: List<String>,
+            hasCategories: Int,
+            classes: List<String>,
+            hasClasses: Int,
+        ): List<String> = throw UnsupportedOperationException()
+
+        override suspend fun getWordBriefsForDecks(
+            deckIds: List<String>,
+            language: String,
+            allowNSFW: Boolean,
+            minDifficulty: Int,
+            maxDifficulty: Int,
+            categories: List<String>,
+            hasCategories: Int,
+            classes: List<String>,
+            hasClasses: Int,
+        ): List<WordBrief> = throw UnsupportedOperationException()
+
+        override suspend fun getAvailableCategories(deckIds: List<String>, language: String, allowNSFW: Boolean): List<String> =
+            throw UnsupportedOperationException()
+
+        override suspend fun getAvailableWordClasses(deckIds: List<String>, language: String, allowNSFW: Boolean): List<String> =
+            availableWordClasses
+
+        override suspend fun getWordClassCounts(deckId: String): List<WordClassCount> = throw UnsupportedOperationException()
+        override suspend fun getDeckCategories(deckId: String): List<String> = throw UnsupportedOperationException()
+        override suspend fun getRandomWordSamples(deckId: String, limit: Int): List<String> = throw UnsupportedOperationException()
+        override suspend fun getDifficultyHistogram(deckId: String): List<DifficultyBucket> = throw UnsupportedOperationException()
+        override suspend fun getRecentWords(deckId: String, limit: Int): List<String> = throw UnsupportedOperationException()
+    }
+
+    private class FakeDeckDao : DeckDao {
+        override suspend fun insertDecks(decks: List<DeckEntity>) = throw UnsupportedOperationException()
+        override fun getDecks(): Flow<List<DeckEntity>> = MutableStateFlow(emptyList())
+        override suspend fun deleteDeck(deckId: String) = throw UnsupportedOperationException()
+        override suspend fun deleteAll() = Unit
+    }
+
+    private class FakeTurnHistoryDao : TurnHistoryDao {
+        override suspend fun insertAll(entries: List<com.example.alias.data.db.TurnHistoryEntity>) = throw UnsupportedOperationException()
+        override fun getRecent(limit: Int): Flow<List<com.example.alias.data.db.TurnHistoryEntity>> = MutableStateFlow(emptyList())
+        override suspend fun deleteAll() = Unit
+    }
+
+    private class FakeSettingsRepository : SettingsRepository {
+        private val flow = MutableStateFlow(Settings())
+        override val settings: Flow<Settings> = flow
+
+        override suspend fun updateRoundSeconds(value: Int) {
+            flow.value = flow.value.copy(roundSeconds = value)
+        }
+        override suspend fun updateTargetWords(value: Int) {
+            flow.value = flow.value.copy(targetWords = value)
+        }
+        override suspend fun updateSkipPolicy(maxSkips: Int, penaltyPerSkip: Int) {
+            flow.value = flow.value.copy(maxSkips = maxSkips, penaltyPerSkip = penaltyPerSkip)
+        }
+        override suspend fun updatePunishSkips(value: Boolean) {
+            flow.value = flow.value.copy(punishSkips = value)
+        }
+        override suspend fun updateLanguagePreference(language: String) {
+            flow.value = flow.value.copy(languagePreference = language)
+        }
+        override suspend fun setEnabledDeckIds(ids: Set<String>) {
+            flow.value = flow.value.copy(enabledDeckIds = ids)
+        }
+        override suspend fun updateAllowNSFW(value: Boolean) {
+            flow.value = flow.value.copy(allowNSFW = value)
+        }
+        override suspend fun updateStemmingEnabled(value: Boolean) {
+            flow.value = flow.value.copy(stemmingEnabled = value)
+        }
+        override suspend fun updateHapticsEnabled(value: Boolean) {
+            flow.value = flow.value.copy(hapticsEnabled = value)
+        }
+        override suspend fun updateSoundEnabled(value: Boolean) {
+            flow.value = flow.value.copy(soundEnabled = value)
+        }
+        override suspend fun updateOneHandedLayout(value: Boolean) {
+            flow.value = flow.value.copy(oneHandedLayout = value)
+        }
+        override suspend fun updateOrientation(value: String) {
+            flow.value = flow.value.copy(orientation = value)
+        }
+        override suspend fun updateUiLanguage(language: String) {
+            flow.value = flow.value.copy(uiLanguage = language)
+        }
+        override suspend fun updateDifficultyFilter(min: Int, max: Int) {
+            flow.value = flow.value.copy(minDifficulty = min, maxDifficulty = max)
+        }
+        override suspend fun setCategoriesFilter(categories: Set<String>) {
+            flow.value = flow.value.copy(selectedCategories = categories)
+        }
+        override suspend fun setWordClassesFilter(classes: Set<String>) {
+            flow.value = flow.value.copy(selectedWordClasses = classes)
+        }
+        override suspend fun setTeams(teams: List<String>) {
+            flow.value = flow.value.copy(teams = teams)
+        }
+        override suspend fun updateVerticalSwipes(value: Boolean) {
+            flow.value = flow.value.copy(verticalSwipes = value)
+        }
+        override suspend fun setTrustedSources(origins: Set<String>) {
+            flow.value = flow.value.copy(trustedSources = origins)
+        }
+        override suspend fun readBundledDeckHashes(): Set<String> = emptySet()
+        override suspend fun writeBundledDeckHashes(entries: Set<String>) = Unit
+        override suspend fun readDeletedBundledDeckIds(): Set<String> = emptySet()
+        override suspend fun addDeletedBundledDeckId(deckId: String) = Unit
+        override suspend fun removeDeletedBundledDeckId(deckId: String) = Unit
+        override suspend fun updateSeenTutorial(value: Boolean) {
+            flow.value = flow.value.copy(seenTutorial = value)
+        }
+        override suspend fun clearAll() {
+            flow.value = Settings()
+        }
+    }
+}

--- a/app/src/test/java/com/example/alias/GameControllerTest.kt
+++ b/app/src/test/java/com/example/alias/GameControllerTest.kt
@@ -1,0 +1,102 @@
+package com.example.alias
+
+import com.example.alias.data.TurnHistoryRepository
+import com.example.alias.data.db.TurnHistoryEntity
+import com.example.alias.data.settings.Settings
+import com.example.alias.domain.GameEngine
+import com.example.alias.domain.GameState
+import com.example.alias.domain.MatchConfig
+import com.example.alias.domain.TurnOutcome
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GameControllerTest {
+    private lateinit var historyRepository: FakeTurnHistoryRepository
+    private lateinit var controller: GameController
+
+    @Before
+    fun setUp() {
+        historyRepository = FakeTurnHistoryRepository()
+        controller = GameController(historyRepository)
+    }
+
+    @Test
+    fun startMatchAppliesSkipPenaltyWhenPunished() = runBlocking {
+        val engine = FakeGameEngine()
+        val settings = Settings(punishSkips = false, penaltyPerSkip = 5)
+
+        controller.startMatch(engine, settings)
+
+        val config = engine.lastConfig
+        requireNotNull(config)
+        assertEquals(0, config.penaltyPerSkip)
+    }
+
+    @Test
+    fun completeTurnSavesHistoryAndAdvances() = runBlocking {
+        val engine = FakeGameEngine()
+        val outcomes = listOf(TurnOutcome("word", correct = true, timestamp = 123L))
+        engine.updateState(
+            GameState.TurnFinished(
+                team = "A",
+                deltaScore = 1,
+                scores = emptyMap(),
+                outcomes = outcomes,
+                matchOver = false,
+            ),
+        )
+
+        controller.completeTurn(engine, mapOf("word" to WordInfo(difficulty = 2, category = "party", wordClass = "NOUN")))
+
+        assertEquals(1, historyRepository.saved.size)
+        val entry = historyRepository.saved.single()
+        assertEquals("word", entry.word)
+        assertEquals(2, entry.difficulty)
+        assertTrue(engine.nextTurnCalled)
+    }
+
+    private class FakeTurnHistoryRepository : TurnHistoryRepository {
+        val saved = mutableListOf<TurnHistoryEntity>()
+        override suspend fun save(entries: List<TurnHistoryEntity>) {
+            saved.addAll(entries)
+        }
+
+        override fun getRecent(limit: Int): kotlinx.coroutines.flow.Flow<List<TurnHistoryEntity>> =
+            MutableStateFlow(emptyList())
+    }
+
+    private class FakeGameEngine : GameEngine {
+        private val backingState = MutableStateFlow<GameState>(GameState.Idle)
+        var lastConfig: MatchConfig? = null
+        var nextTurnCalled = false
+
+        override val state: StateFlow<GameState>
+            get() = backingState
+
+        override suspend fun startMatch(config: MatchConfig, teams: List<String>, seed: Long) {
+            lastConfig = config
+        }
+
+        override suspend fun correct() = throw UnsupportedOperationException()
+        override suspend fun skip() = throw UnsupportedOperationException()
+
+        override suspend fun nextTurn() {
+            nextTurnCalled = true
+        }
+
+        override suspend fun startTurn() = Unit
+
+        override suspend fun overrideOutcome(index: Int, correct: Boolean) = Unit
+
+        override suspend fun peekNextWord(): String? = null
+
+        fun updateState(newState: GameState) {
+            backingState.value = newState
+        }
+    }
+}

--- a/app/src/test/java/com/example/alias/SettingsControllerTest.kt
+++ b/app/src/test/java/com/example/alias/SettingsControllerTest.kt
@@ -1,0 +1,141 @@
+package com.example.alias
+
+import com.example.alias.data.DeckRepository
+import com.example.alias.data.db.DeckEntity
+import com.example.alias.data.pack.ParsedPack
+import com.example.alias.data.settings.Settings
+import com.example.alias.data.settings.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SettingsControllerTest {
+    private lateinit var deckRepository: FakeDeckRepository
+    private lateinit var settingsRepository: FakeSettingsRepository
+    private lateinit var controller: SettingsController
+
+    @Before
+    fun setUp() {
+        deckRepository = FakeDeckRepository()
+        settingsRepository = FakeSettingsRepository()
+        controller = SettingsController(settingsRepository, deckRepository)
+    }
+
+    @Test
+    fun addTrustedSourceRejectsInvalidScheme() = runBlocking {
+        val result = controller.addTrustedSource("http://example.com")
+        assertTrue(result is SettingsController.TrustedSourceResult.Invalid)
+    }
+
+    @Test
+    fun applySettingsUpdateChangesLanguageDecks() = runBlocking {
+        val initialSettings = Settings(
+            languagePreference = "en",
+            enabledDeckIds = setOf("en-1"),
+        )
+        settingsRepository.state.value = initialSettings
+        deckRepository.state.value = listOf(
+            DeckEntity("es-1", "Spanish", "es", isOfficial = true, isNSFW = false, version = 1, updatedAt = 0L),
+        )
+
+        val request = SettingsUpdateRequest.from(initialSettings).copy(language = "es")
+        val result = controller.applySettingsUpdate(request)
+
+        assertEquals("es", settingsRepository.state.value.languagePreference)
+        val change = result.languageChange
+        assertEquals(setOf("es-1"), change?.newDeckIds)
+        assertEquals(setOf("en-1"), change?.previousDeckIds)
+        assertEquals(setOf("es-1"), settingsRepository.state.value.enabledDeckIds)
+    }
+
+    private class FakeDeckRepository : DeckRepository {
+        val state = MutableStateFlow<List<DeckEntity>>(emptyList())
+        override fun getDecks(): Flow<List<DeckEntity>> = state
+        override suspend fun getWordCount(deckId: String): Int = throw UnsupportedOperationException()
+        override suspend fun getDifficultyHistogram(deckId: String): List<com.example.alias.data.db.DifficultyBucket> =
+            throw UnsupportedOperationException()
+        override suspend fun getRecentWords(deckId: String, limit: Int): List<String> = throw UnsupportedOperationException()
+        override suspend fun importJson(content: String) = throw UnsupportedOperationException()
+        override suspend fun importPack(pack: ParsedPack) = throw UnsupportedOperationException()
+        override suspend fun deleteDeck(deckId: String) = throw UnsupportedOperationException()
+    }
+
+    private class FakeSettingsRepository : SettingsRepository {
+        val state = MutableStateFlow(Settings())
+        override val settings: Flow<Settings> = state
+
+        override suspend fun updateRoundSeconds(value: Int) {
+            state.value = state.value.copy(roundSeconds = value)
+        }
+        override suspend fun updateTargetWords(value: Int) {
+            state.value = state.value.copy(targetWords = value)
+        }
+        override suspend fun updateSkipPolicy(maxSkips: Int, penaltyPerSkip: Int) {
+            state.value = state.value.copy(maxSkips = maxSkips, penaltyPerSkip = penaltyPerSkip)
+        }
+        override suspend fun updatePunishSkips(value: Boolean) {
+            state.value = state.value.copy(punishSkips = value)
+        }
+        override suspend fun updateLanguagePreference(language: String) {
+            require(language.matches(Regex("^[A-Za-z]{2,8}(-[A-Za-z0-9]{1,8})*$")))
+            state.value = state.value.copy(languagePreference = language)
+        }
+        override suspend fun setEnabledDeckIds(ids: Set<String>) {
+            state.value = state.value.copy(enabledDeckIds = ids)
+        }
+        override suspend fun updateAllowNSFW(value: Boolean) {
+            state.value = state.value.copy(allowNSFW = value)
+        }
+        override suspend fun updateStemmingEnabled(value: Boolean) {
+            state.value = state.value.copy(stemmingEnabled = value)
+        }
+        override suspend fun updateHapticsEnabled(value: Boolean) {
+            state.value = state.value.copy(hapticsEnabled = value)
+        }
+        override suspend fun updateSoundEnabled(value: Boolean) {
+            state.value = state.value.copy(soundEnabled = value)
+        }
+        override suspend fun updateOneHandedLayout(value: Boolean) {
+            state.value = state.value.copy(oneHandedLayout = value)
+        }
+        override suspend fun updateOrientation(value: String) {
+            state.value = state.value.copy(orientation = value)
+        }
+        override suspend fun updateUiLanguage(language: String) {
+            state.value = state.value.copy(uiLanguage = language)
+        }
+        override suspend fun updateDifficultyFilter(min: Int, max: Int) {
+            state.value = state.value.copy(minDifficulty = min, maxDifficulty = max)
+        }
+        override suspend fun setCategoriesFilter(categories: Set<String>) {
+            state.value = state.value.copy(selectedCategories = categories)
+        }
+        override suspend fun setWordClassesFilter(classes: Set<String>) {
+            state.value = state.value.copy(selectedWordClasses = classes)
+        }
+        override suspend fun setTeams(teams: List<String>) {
+            state.value = state.value.copy(teams = teams)
+        }
+        override suspend fun updateVerticalSwipes(value: Boolean) {
+            state.value = state.value.copy(verticalSwipes = value)
+        }
+        override suspend fun setTrustedSources(origins: Set<String>) {
+            state.value = state.value.copy(trustedSources = origins)
+        }
+        override suspend fun readBundledDeckHashes(): Set<String> = emptySet()
+        override suspend fun writeBundledDeckHashes(entries: Set<String>) = Unit
+        override suspend fun readDeletedBundledDeckIds(): Set<String> = emptySet()
+        override suspend fun addDeletedBundledDeckId(deckId: String) = Unit
+        override suspend fun removeDeletedBundledDeckId(deckId: String) = Unit
+        override suspend fun updateSeenTutorial(value: Boolean) {
+            state.value = state.value.copy(seenTutorial = value)
+        }
+        override suspend fun clearAll() {
+            state.value = Settings()
+        }
+    }
+}

--- a/data/src/main/java/com/example/alias/data/db/Migrations.kt
+++ b/data/src/main/java/com/example/alias/data/db/Migrations.kt
@@ -1,7 +1,6 @@
 package com.example.alias.data.db
 
 import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
  * Database migrations for AliasDatabase.
@@ -15,7 +14,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 // Migration 1→2: Add turn_history table for game history tracking
 val MIGRATION_1_2 = Migration(1, 2) { database ->
-    database.execSQL("""
+    database.execSQL(
+        """
         CREATE TABLE IF NOT EXISTS `turn_history` (
             `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
             `team` TEXT NOT NULL,
@@ -23,7 +23,8 @@ val MIGRATION_1_2 = Migration(1, 2) { database ->
             `correct` INTEGER NOT NULL,
             `timestamp` INTEGER NOT NULL
         )
-    """)
+    """,
+    )
 }
 
 // Migration 2→3: Add indexes to words table for better query performance
@@ -40,7 +41,8 @@ val MIGRATION_3_4 = Migration(3, 4) { database ->
 // Migration 4→5: Add word_classes table and unique constraint on words
 val MIGRATION_4_5 = Migration(4, 5) { database ->
     // Create word_classes table for word classification
-    database.execSQL("""
+    database.execSQL(
+        """
         CREATE TABLE IF NOT EXISTS `word_classes` (
             `deckId` TEXT NOT NULL,
             `wordText` TEXT NOT NULL,
@@ -48,7 +50,8 @@ val MIGRATION_4_5 = Migration(4, 5) { database ->
             PRIMARY KEY(`deckId`, `wordText`, `wordClass`),
             FOREIGN KEY(`deckId`, `wordText`) REFERENCES `words`(`deckId`, `text`) ON UPDATE CASCADE ON DELETE CASCADE
         )
-    """)
+    """,
+    )
 
     // Add indexes for word_classes table
     database.execSQL("CREATE INDEX IF NOT EXISTS `index_word_classes_wordClass` ON `word_classes` (`wordClass`)")
@@ -78,5 +81,5 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_3_4,
     MIGRATION_4_5,
     MIGRATION_5_6,
-    MIGRATION_6_7
+    MIGRATION_6_7,
 )

--- a/data/src/main/java/com/example/alias/data/di/DataModule.kt
+++ b/data/src/main/java/com/example/alias/data/di/DataModule.kt
@@ -15,8 +15,8 @@ import com.example.alias.data.DeckRepository
 import com.example.alias.data.DeckRepositoryImpl
 import com.example.alias.data.TurnHistoryRepository
 import com.example.alias.data.TurnHistoryRepositoryImpl
-import com.example.alias.data.db.AliasDatabase
 import com.example.alias.data.db.ALL_MIGRATIONS
+import com.example.alias.data.db.AliasDatabase
 import com.example.alias.data.db.DeckDao
 import com.example.alias.data.db.TurnHistoryDao
 import com.example.alias.data.db.WordDao

--- a/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
+++ b/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
@@ -1,5 +1,6 @@
 package com.example.alias.data.settings
 
+import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
@@ -11,7 +12,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.util.Locale
-import android.util.Log
 
 private val DEFAULT_TEAMS = listOf("Red", "Blue")
 

--- a/data/src/test/java/com/example/alias/data/DatabaseMigrationTest.kt
+++ b/data/src/test/java/com/example/alias/data/DatabaseMigrationTest.kt
@@ -7,8 +7,8 @@ import com.example.alias.data.db.MIGRATION_3_4
 import com.example.alias.data.db.MIGRATION_4_5
 import com.example.alias.data.db.MIGRATION_5_6
 import com.example.alias.data.db.MIGRATION_6_7
-import org.junit.Test
 import org.junit.Assert.*
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -60,8 +60,11 @@ class DatabaseMigrationTest {
         for (i in 0 until versionRanges.size - 1) {
             val currentEnd = versionRanges[i].second
             val nextStart = versionRanges[i + 1].first
-            assertEquals("Migration $i end version should match migration ${i + 1} start version",
-                currentEnd, nextStart)
+            assertEquals(
+                "Migration $i end version should match migration ${i + 1} start version",
+                currentEnd,
+                nextStart,
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- extract deck import/management logic into a new `DeckManager` and wire it into `MainViewModel`
- move settings persistence and game engine coordination into `SettingsController` and `GameController`
- update Hilt wiring and add unit tests for the new collaborators

## Testing
- ./gradlew --console=plain spotlessCheck
- ./gradlew --console=plain :app:testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_b_68cea5a398e0832cb9c9f9c6f8b79973