### PR TITLE
[app] Externalize remaining UI strings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,10 +29,10 @@
 - Bundled assets change detection: implemented; consider per-deck id tracking and pruning removed assets.
 - Room migrations: implement proper migrations for DB version upgrades; remove destructive fallback in production builds.
 - Audio UX: add sound hooks for countdown, turn start, final 5 seconds with vibration, and turn end (no assets committed).
+- Localization: ensure *all* strings (including Settings, About, and any new UI) are fully externalized.
 
 ## Backlog
 - Add toggleable score-to-target regime with configurable goal in Settings and wire it into game flow.
-- Localization: ensure *all* strings (including Settings, About, and any new UI) are fully externalized.
 - Refactor end-of-turn summary UI: relocate turn statistics, collapse detailed breakdown/time graph (taller), per-word blocks with colored backgrounds acting as correct/incorrect toggles, and show time-between-word graph.
 - Update History screen: hide filters/stats by default, add Reset History action, and align detailed game view with end-of-turn summary layout.
 - Deck details: ensure recent words pull from games played with the selected deck.

--- a/app/src/main/java/com/example/alias/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/about/AboutScreen.kt
@@ -70,12 +70,14 @@ fun aboutScreen() {
             ElevatedCard(Modifier.fillMaxWidth()) {
                 Column(Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(stringResource(R.string.links_label), style = MaterialTheme.typography.titleMedium)
+                    val sourceCodeLink = stringResource(R.string.about_source_code_link)
+                    val sourceCodeUrl = stringResource(R.string.about_source_code_url)
                     ListItem(
                         leadingContent = { Icon(Icons.Filled.Code, contentDescription = null) },
                         headlineContent = { Text(stringResource(R.string.source_code_label)) },
-                        supportingContent = { Text("github.com/ooodnakov/alias-game") },
+                        supportingContent = { Text(sourceCodeLink) },
                         trailingContent = { Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null) },
-                        modifier = Modifier.clickable { uriHandler.openUri("https://github.com/ooodnakov/alias-game") },
+                        modifier = Modifier.clickable { uriHandler.openUri(sourceCodeUrl) },
                     )
                     HorizontalDivider()
                     ListItem(

--- a/app/src/main/java/com/example/alias/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/about/AboutScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -70,14 +71,15 @@ fun aboutScreen() {
             ElevatedCard(Modifier.fillMaxWidth()) {
                 Column(Modifier.fillMaxWidth().padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(stringResource(R.string.links_label), style = MaterialTheme.typography.titleMedium)
-                    val sourceCodeLink = stringResource(R.string.about_source_code_link)
-                    val sourceCodeUrl = stringResource(R.string.about_source_code_url)
+                    val context = LocalContext.current
                     ListItem(
                         leadingContent = { Icon(Icons.Filled.Code, contentDescription = null) },
                         headlineContent = { Text(stringResource(R.string.source_code_label)) },
-                        supportingContent = { Text(sourceCodeLink) },
+                        supportingContent = { Text(stringResource(R.string.about_source_code_link)) },
                         trailingContent = { Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null) },
-                        modifier = Modifier.clickable { uriHandler.openUri(sourceCodeUrl) },
+                        modifier = Modifier.clickable {
+                            uriHandler.openUri(context.getString(R.string.about_source_code_url))
+                        },
                     )
                     HorizontalDivider()
                     ListItem(

--- a/app/src/main/java/com/example/alias/ui/common/Scoreboard.kt
+++ b/app/src/main/java/com/example/alias/ui/common/Scoreboard.kt
@@ -54,7 +54,7 @@ fun scoreboard(scores: Map<String, Int>) {
                     Spacer(modifier = Modifier.width(28.dp))
                 }
                 Text(
-                    text = "$team: $score$suffix",
+                    text = stringResource(R.string.scoreboard_entry, team, score, suffix),
                     style = textStyle,
                     color = textColor,
                 )

--- a/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
@@ -286,11 +286,13 @@ fun decksScreen(vm: MainViewModel, onDeckSelected: (DeckEntity) -> Unit) {
         if (deckToPermanentlyDelete != null) {
             AlertDialog(
                 onDismissRequest = { deckPendingPermanentDelete = null },
-                title = { Text("Permanently Delete Deck") },
+                title = { Text(stringResource(R.string.deck_permanent_delete_dialog_title)) },
                 text = {
                     Text(
-                        "Are you sure you want to permanently delete " +
-                            "\"${deckToPermanentlyDelete.name}\"? This action cannot be undone.",
+                        stringResource(
+                            R.string.deck_permanent_delete_dialog_message,
+                            deckToPermanentlyDelete.name,
+                        ),
                     )
                 },
                 confirmButton = {
@@ -298,7 +300,7 @@ fun decksScreen(vm: MainViewModel, onDeckSelected: (DeckEntity) -> Unit) {
                         vm.permanentlyDeleteImportedDeck(deckToPermanentlyDelete)
                         deckPendingPermanentDelete = null
                     }) {
-                        Text("Delete Permanently")
+                        Text(stringResource(R.string.deck_delete_permanently_action))
                     }
                 },
                 dismissButton = {
@@ -471,7 +473,7 @@ private fun deckCard(
                                 ) {
                                     if (deck.isOfficial) {
                                         DropdownMenuItem(
-                                            text = { Text("Hide Deck") },
+                                            text = { Text(stringResource(R.string.deck_hide_action)) },
                                             leadingIcon = {
                                                 Icon(
                                                     imageVector = Icons.Filled.Delete,
@@ -485,7 +487,9 @@ private fun deckCard(
                                         )
                                     } else {
                                         DropdownMenuItem(
-                                            text = { Text("Delete Permanently") },
+                                            text = {
+                                                Text(stringResource(R.string.deck_delete_permanently_action))
+                                            },
                                             leadingIcon = {
                                                 Icon(
                                                     imageVector = Icons.Filled.Delete,
@@ -926,19 +930,19 @@ private fun deckDeletedDecksSheet(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Text(
-            text = "Deleted Decks",
+            text = stringResource(R.string.deleted_decks),
             style = MaterialTheme.typography.titleLarge,
         )
 
         if (deletedBundledDeckIds.isEmpty()) {
             Text(
-                text = "No deleted decks",
+                text = stringResource(R.string.deck_deleted_empty),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } else {
             Text(
-                text = "Deleted Bundled Decks (tap to restore):",
+                text = stringResource(R.string.deck_deleted_bundled_hint),
                 style = MaterialTheme.typography.titleMedium,
             )
 
@@ -947,10 +951,12 @@ private fun deckDeletedDecksSheet(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     ListItem(
-                        headlineContent = { Text("Bundled Deck: $deckId") },
+                        headlineContent = {
+                            Text(stringResource(R.string.deck_deleted_bundled_label, deckId))
+                        },
                         trailingContent = {
                             TextButton(onClick = { onRestoreDeck(deckId) }) {
-                                Text("Restore")
+                                Text(stringResource(R.string.restore))
                             }
                         },
                         modifier = Modifier.padding(8.dp),
@@ -961,7 +967,7 @@ private fun deckDeletedDecksSheet(
             HorizontalDivider()
 
             Text(
-                text = "Note: Imported decks that are deleted are permanently removed and cannot be restored.",
+                text = stringResource(R.string.deck_deleted_imported_hint),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
@@ -657,7 +657,10 @@ fun gameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
                 verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Text("🎉 Match over 🎉", style = MaterialTheme.typography.headlineSmall)
+                Text(
+                    stringResource(R.string.match_finished_message),
+                    style = MaterialTheme.typography.headlineSmall,
+                )
                 scoreboard(s.scores)
                 Text(stringResource(R.string.start_new_match))
                 Button(onClick = {

--- a/app/src/main/java/com/example/alias/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/home/HomeScreen.kt
@@ -443,7 +443,9 @@ private fun favoriteDecksSection(
                 if (extra > 0) {
                     AssistChip(
                         onClick = onDecks,
-                        label = { Text("+$extra") },
+                        label = {
+                            Text(stringResource(R.string.home_more_favorites, extra))
+                        },
                         colors = AssistChipDefaults.assistChipColors(
                             containerColor = contentColor.copy(alpha = 0.08f),
                             labelColor = contentColor,

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -28,6 +28,7 @@
     <string name="home_favorite_decks">Любимые колоды</string>
     <string name="home_empty_favorites">Включите колоды, чтобы увидеть их здесь.</string>
     <string name="home_recent_highlight">Последний момент</string>
+    <string name="home_more_favorites">+%1$d</string>
     <string name="home_highlight_correct">Команда %1$s угадала «%2$s».</string>
     <string name="home_highlight_skip">Команда %1$s пропустила «%2$s».</string>
     <string name="home_highlight_empty">Сыграйте раунд, чтобы собрать лучшие моменты.</string>
@@ -61,6 +62,7 @@
     <string name="skip">Пропустить</string>
     <string name="restart_match">Перезапустить матч</string>
     <string name="start_new_match">Новый матч: Настройки или Перезапуск.</string>
+    <string name="match_finished_message">🎉 Матч завершён 🎉</string>
     <string name="start_turn">Начать</string>
     <plurals name="turn_pending_status">
         <item quantity="one">До победы осталось %d слово!</item>
@@ -69,6 +71,7 @@
         <item quantity="other">До победы осталось %d слов!</item>
     </plurals>
     <string name="scoreboard">Счёт</string>
+    <string name="scoreboard_entry">%1$s: %2$d%3$s</string>
     <string name="end_match">Завершить матч</string>
     <string name="next_team">Следующая команда</string>
     <string name="turn_summary">Ход: %s</string>
@@ -176,6 +179,10 @@
     <string name="import_decks_action">Импорт колод</string>
     <string name="no_decks_call_to_action">Импортируйте колоду, чтобы начать игру.</string>
     <string name="deleted_decks">Удаленные колоды</string>
+    <string name="deck_deleted_empty">Удалённых колод нет</string>
+    <string name="deck_deleted_bundled_hint">Удалённые встроенные колоды (нажмите, чтобы восстановить):</string>
+    <string name="deck_deleted_bundled_label">Встроенная колода: %1$s</string>
+    <string name="deck_deleted_imported_hint">Важно: импортированные колоды при удалении стираются окончательно и не могут быть восстановлены.</string>
     <string name="deck_filters_description">Выберите слова для следующего матча.</string>
     <string name="import_sheet_title">Импорт колод</string>
     <string name="import_sheet_hint">Установите колоды из файлов или доверенных ссылок.</string>
@@ -186,8 +193,12 @@
     <string name="deck_card_view_details">Подробнее</string>
     <string name="deck_more_actions">Опции колоды</string>
     <string name="deck_delete_action">Удалить колоду</string>
+    <string name="deck_hide_action">Скрыть колоду</string>
+    <string name="deck_delete_permanently_action">Удалить навсегда</string>
     <string name="deck_delete_dialog_title">Удалить колоду?</string>
     <string name="deck_delete_dialog_message">Удалить"%1$s" и слова в ней? Это действие не может быть отменено.</string>
+    <string name="deck_permanent_delete_dialog_title">Удалить колоду навсегда?</string>
+    <string name="deck_permanent_delete_dialog_message">Вы уверены, что хотите навсегда удалить «%1$s»? Это действие нельзя отменить.</string>
     <string name="deck_difficulty_title">Распределение сложности</string>
     <string name="deck_difficulty_empty">Данные о сложности недоступны.</string>
     <string name="deck_recent_words_title">Недавние слова</string>
@@ -217,6 +228,7 @@
     <string name="version_label">Версия %1$s</string>
     <string name="links_label">Ссылки</string>
     <string name="source_code_label">Исходный код</string>
+    <string name="about_source_code_link">github.com/ooodnakov/alias-game</string>
     <string name="report_issue_label">Сообщить о баге</string>
     <string name="open_github_issues_label">Открыть задачи GitHub</string>
     <string name="author_line">Автор: Aleksandr Odnakov</string>
@@ -262,4 +274,5 @@
     <string name="reset_confirm_message">Удалит колоды, слова, историю и настройки. Отменить нельзя.</string>
     <string name="cancel">Отмена</string>
     <string name="confirm">Подтвердить</string>
+    <string name="restore">Восстановить</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="home_favorite_decks">Favorite decks</string>
     <string name="home_empty_favorites">Enable decks to feature them here.</string>
     <string name="home_recent_highlight">Recent highlight</string>
+    <string name="home_more_favorites">+%1$d</string>
     <string name="home_highlight_correct">%1$s nailed “%2$s”.</string>
     <string name="home_highlight_skip">%1$s passed on “%2$s”.</string>
     <string name="home_highlight_empty">Play a round to build your highlight reel.</string>
@@ -55,12 +56,14 @@
     <string name="skip">Skip</string>
     <string name="restart_match">Restart Match</string>
     <string name="start_new_match">Start a new match from Settings or Restart.</string>
+    <string name="match_finished_message">🎉 Match over 🎉</string>
     <string name="start_turn">Start</string>
     <plurals name="turn_pending_status">
         <item quantity="one">Only %d correct word to win!</item>
         <item quantity="other">Only %d correct words to win!</item>
     </plurals>
     <string name="scoreboard">Scoreboard</string>
+    <string name="scoreboard_entry">%1$s: %2$d%3$s</string>
     <string name="end_match">End Match</string>
     <string name="next_team">Next Team</string>
     <string name="turn_summary">Turn summary for %s</string>
@@ -154,6 +157,10 @@
     <string name="import_decks_action">Import decks</string>
     <string name="no_decks_call_to_action">Import a deck to start playing.</string>
     <string name="deleted_decks">Deleted Decks</string>
+    <string name="deck_deleted_empty">No deleted decks</string>
+    <string name="deck_deleted_bundled_hint">Deleted bundled decks (tap to restore):</string>
+    <string name="deck_deleted_bundled_label">Bundled deck: %1$s</string>
+    <string name="deck_deleted_imported_hint">Note: Imported decks that are deleted are permanently removed and cannot be restored.</string>
     <string name="deck_filters_description">Choose which words appear in the next match.</string>
     <string name="import_sheet_title">Import decks</string>
     <string name="import_sheet_hint">Install decks from files or a trusted link.</string>
@@ -164,8 +171,12 @@
     <string name="deck_card_view_details">View details</string>
     <string name="deck_more_actions">Deck options</string>
     <string name="deck_delete_action">Delete deck</string>
+    <string name="deck_hide_action">Hide deck</string>
+    <string name="deck_delete_permanently_action">Delete permanently</string>
     <string name="deck_delete_dialog_title">Delete deck?</string>
     <string name="deck_delete_dialog_message">Remove "%1$s" and its words? This cannot be undone.</string>
+    <string name="deck_permanent_delete_dialog_title">Permanently delete deck?</string>
+    <string name="deck_permanent_delete_dialog_message">Are you sure you want to permanently delete "%1$s"? This action cannot be undone.</string>
     <string name="deck_difficulty_title">Difficulty spread</string>
     <string name="deck_difficulty_empty">Difficulty data unavailable.</string>
     <string name="deck_recent_words_title">Recent words</string>
@@ -212,6 +223,8 @@
     <string name="version_label">Version %1$s</string>
     <string name="links_label">Links</string>
     <string name="source_code_label">Source code</string>
+    <string name="about_source_code_link">github.com/ooodnakov/alias-game</string>
+    <string name="about_source_code_url" translatable="false">https://github.com/ooodnakov/alias-game</string>
     <string name="report_issue_label">Report an issue</string>
     <string name="open_github_issues_label">Open GitHub issues</string>
     <string name="author_line">Author: Aleksandr Odnakov</string>
@@ -266,6 +279,7 @@
     <string name="reset_confirm_message">This clears decks, words, history, and settings. This cannot be undone.</string>
     <string name="cancel">Cancel</string>
     <string name="confirm">Confirm</string>
+    <string name="restore">Restore</string>
     <string name="support_and_data_label">Support &amp; data</string>
 
     <string-array name="team_name_suggestions">


### PR DESCRIPTION
## Summary
- externalize remaining UI literals on the home, decks, game, scoreboard, and about screens in favor of string resources
- add localized English and Russian strings for the new resources, including deck deletion flows and scoreboard formatting

## Testing
- `./gradlew --console=plain :domain:test :data:test :app:testDebugUnitTest :app:assembleDebug`
- `./gradlew --console=plain spotlessCheck detekt :domain:test :data:test :app:testDebugUnitTest :app:assembleDebug` *(fails: existing Spotless violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_b_68cecfafef54832cb3b92dc8a9bc39af