### PR TITLE
Refactor turn summary UI

### DIFF
--- a/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
@@ -201,43 +201,35 @@ private fun timelineCard(
                     title = stringResource(R.string.timeline_graphs_title),
                     subtitle = stringResource(R.string.timeline_graphs_subtitle),
                     modifier = Modifier.padding(horizontal = 20.dp),
+                    contentArrangement = Arrangement.spacedBy(16.dp),
                 ) {
-                    Column(
+                    scoreProgressGraph(
+                        events = timeline.events,
                         modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
-                    ) {
-                        scoreProgressGraph(
-                            events = timeline.events,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        timeBetweenWordsGraph(
-                            events = timeline.events,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
+                    )
+                    timeBetweenWordsGraph(
+                        events = timeline.events,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
                 }
                 ExpandableSection(
                     title = stringResource(R.string.timeline_breakdown_title),
                     subtitle = stringResource(R.string.timeline_breakdown_subtitle),
                     modifier = Modifier.padding(horizontal = 20.dp),
+                    contentArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        timeline.segments.forEach { segment ->
+                    timeline.segments.forEach { segment ->
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            timelineSegmentHeader(
+                                segment = segment,
+                                penaltyPerSkip = penaltyPerSkip,
+                            )
                             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                timelineSegmentHeader(
-                                    segment = segment,
-                                    penaltyPerSkip = penaltyPerSkip,
-                                )
-                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    segment.events.forEach { event ->
-                                        timelineEventBlock(
-                                            event = event,
-                                            onToggle = { isCorrect -> onOverride(event.index, isCorrect) },
-                                        )
-                                    }
+                                segment.events.forEach { event ->
+                                    timelineEventBlock(
+                                        event = event,
+                                        onToggle = { isCorrect -> onOverride(event.index, isCorrect) },
+                                    )
                                 }
                             }
                         }
@@ -729,6 +721,7 @@ private fun ExpandableSection(
     subtitle: String?,
     modifier: Modifier = Modifier,
     initiallyExpanded: Boolean = false,
+    contentArrangement: Arrangement.Vertical = Arrangement.spacedBy(12.dp),
     content: @Composable ColumnScope.() -> Unit,
 ) {
     var expanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
@@ -785,7 +778,7 @@ private fun ExpandableSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = contentArrangement,
             content = content,
         )
     }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -110,12 +110,17 @@
         <item quantity="many">%d бонусных серий</item>
         <item quantity="other">%d бонусные серии</item>
     </plurals>
+    <string name="turn_summary_stats_title">Статистика хода</string>
     <string name="turn_summary_stat_time_label">Затраченное время</string>
     <string name="turn_summary_stat_time_value">%1$.1f с</string>
     <string name="turn_summary_stat_time_under_second_value">&lt;1 с</string>
     <string name="turn_timeline_title">Хронология хода</string>
     <string name="timeline_score_breakdown">Посмотрите, как команда набрала очки в этом раунде.</string>
+    <string name="timeline_graphs_title">Графики хода</string>
+    <string name="timeline_graphs_subtitle">Следите за динамикой счёта и темпа.</string>
     <string name="timeline_score_graph_label">Очки по времени</string>
+    <string name="timeline_time_between_graph_label">Интервал между словами</string>
+    <string name="timeline_time_between_graph_average">Среднее %1$.1f с между словами</string>
     <string name="timeline_no_events">В этом ходу слова не записывались.</string>
     <string name="timeline_bonus_label">Бонус</string>
     <string name="timeline_change">%1$+d</string>
@@ -128,6 +133,13 @@
     <string name="timeline_header_skip_no_penalty">Штраф не применён</string>
     <string name="timeline_mark_correct">Отметить как верное</string>
     <string name="timeline_mark_incorrect">Отметить как неверное</string>
+    <string name="timeline_breakdown_title">Разбор слов</string>
+    <string name="timeline_breakdown_subtitle">Нажмите на слово, чтобы отметить верное или пропущенное.</string>
+    <string name="timeline_section_state_expanded">Развернуто</string>
+    <string name="timeline_section_state_collapsed">Свернуто</string>
+    <string name="timeline_word_state_correct">Верно</string>
+    <string name="timeline_word_state_skipped">Пропущено</string>
+    <string name="timeline_word_state_pending">Проверить</string>
     <plurals name="timeline_correct">
         <item quantity="one">Верное слово</item>
         <item quantity="few">Серия верных ×%d</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,12 +92,17 @@
         <item quantity="one">%d bonus streak</item>
         <item quantity="other">%d bonus streaks</item>
     </plurals>
+    <string name="turn_summary_stats_title">Turn stats</string>
     <string name="turn_summary_stat_time_label">Time used</string>
     <string name="turn_summary_stat_time_value">%1$.1fs</string>
     <string name="turn_summary_stat_time_under_second_value">&lt;1s</string>
     <string name="turn_timeline_title">Turn timeline</string>
     <string name="timeline_score_breakdown">See how the team built this round\'s score.</string>
+    <string name="timeline_graphs_title">Turn graphs</string>
+    <string name="timeline_graphs_subtitle">View score trends and pacing.</string>
     <string name="timeline_score_graph_label">Score over time</string>
+    <string name="timeline_time_between_graph_label">Time between words</string>
+    <string name="timeline_time_between_graph_average">Avg %1$.1fs between words</string>
     <string name="timeline_no_events">No words were recorded this turn.</string>
     <string name="timeline_bonus_label">Bonus</string>
     <string name="timeline_change">%1$+d</string>
@@ -110,6 +115,13 @@
     <string name="timeline_header_skip_no_penalty">No penalty applied</string>
     <string name="timeline_mark_correct">Mark correct</string>
     <string name="timeline_mark_incorrect">Mark incorrect</string>
+    <string name="timeline_breakdown_title">Word breakdown</string>
+    <string name="timeline_breakdown_subtitle">Tap any word to toggle correct or skipped.</string>
+    <string name="timeline_section_state_expanded">Expanded</string>
+    <string name="timeline_section_state_collapsed">Collapsed</string>
+    <string name="timeline_word_state_correct">Correct</string>
+    <string name="timeline_word_state_skipped">Skipped</string>
+    <string name="timeline_word_state_pending">Needs review</string>
     <plurals name="timeline_correct">
         <item quantity="one">Correct word</item>
         <item quantity="other">Correct streak ×%d</item>


### PR DESCRIPTION
## Summary
- Move the turn statistics into a dedicated card beneath the scoreboard for easier scanning.
- Collapse the timeline score details behind expandable sections, add a taller score graph, and introduce a time-between-words chart.
- Replace per-word rows with tappable colored blocks that toggle outcomes directly on the summary screen.

## Testing
- `./gradlew --console=plain spotlessCheck` *(fails: existing formatting violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_b_68ceded97b30832cb8268f52c58586ee