### PR TITLE
Add history reset flow and restyle history screen

### DIFF
--- a/app/src/main/java/com/example/alias/GameController.kt
+++ b/app/src/main/java/com/example/alias/GameController.kt
@@ -70,4 +70,8 @@ class GameController
         }
 
         fun recentHistory(limit: Int): Flow<List<TurnHistoryEntity>> = historyRepository.getRecent(limit)
+
+        suspend fun clearHistory() {
+            historyRepository.clear()
+        }
     }

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -413,6 +413,13 @@ class MainViewModel
             }
         }
 
+        fun resetHistory() {
+            viewModelScope.launch {
+                gameController.clearHistory()
+                _uiEvents.tryEmit(UiEvent(message = "History cleared", actionLabel = "OK"))
+            }
+        }
+
         fun restartMatch() {
             viewModelScope.launch {
                 val currentSettings = settingsController.settings.first()

--- a/app/src/main/java/com/example/alias/navigation/AliasNavHost.kt
+++ b/app/src/main/java/com/example/alias/navigation/AliasNavHost.kt
@@ -145,7 +145,10 @@ fun aliasNavHost(
             appScaffold(snackbarHostState = snackbarHostState) {
                 val historyFlow = remember { viewModel.recentHistory(HISTORY_LIMIT) }
                 val history by historyFlow.collectAsState(initial = emptyList())
-                historyScreen(history)
+                historyScreen(
+                    history = history,
+                    onResetHistory = { viewModel.resetHistory() },
+                )
             }
         }
         composable("about") {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,6 +205,11 @@
     <string name="history_section_recent_turns">Recent turns</string>
     <string name="history_hide_header">Hide filters &amp; stats</string>
     <string name="history_show_header">Show filters &amp; stats</string>
+    <string name="history_reset_action">Reset history</string>
+    <string name="history_reset_dialog_title">Reset history?</string>
+    <string name="history_reset_dialog_message">Clear all saved turns? This cannot be undone.</string>
+    <string name="history_reset_dialog_confirm">Reset</string>
+    <string name="history_reset_dialog_cancel">Cancel</string>
     <string name="history_recent_count">%1$d of %2$d turns</string>
     <string name="history_no_entries_for_filters">No turns match your filters yet.</string>
     <string name="history_performance_summary">%1$d/%2$d correct (%3$d%%)</string>

--- a/app/src/test/java/com/example/alias/GameControllerTest.kt
+++ b/app/src/test/java/com/example/alias/GameControllerTest.kt
@@ -86,6 +86,10 @@ class GameControllerTest {
 
         override fun getRecent(limit: Int): kotlinx.coroutines.flow.Flow<List<TurnHistoryEntity>> =
             MutableStateFlow(emptyList())
+
+        override suspend fun clear() {
+            saved.clear()
+        }
     }
 
     private class FakeGameEngine : GameEngine {

--- a/data/src/main/java/com/example/alias/data/TurnHistoryRepository.kt
+++ b/data/src/main/java/com/example/alias/data/TurnHistoryRepository.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 interface TurnHistoryRepository {
     suspend fun save(entries: List<TurnHistoryEntity>)
     fun getRecent(limit: Int): Flow<List<TurnHistoryEntity>>
+    suspend fun clear()
 }
 
 class TurnHistoryRepositoryImpl(
@@ -17,4 +18,8 @@ class TurnHistoryRepositoryImpl(
     }
 
     override fun getRecent(limit: Int): Flow<List<TurnHistoryEntity>> = dao.getRecent(limit)
+
+    override suspend fun clear() {
+        dao.deleteAll()
+    }
 }


### PR DESCRIPTION
## Summary
- add a clear method on the history repository and expose it through GameController/MainViewModel
- add a reset history action on the History screen with confirmation and collapse filters by default
- refresh the history entry cards to align with the turn summary styling and add supporting strings

## Testing
- ./gradlew spotlessApply
- ./gradlew :app:testDebugUnitTest :data:test

------
https://chatgpt.com/codex/tasks/task_b_68cedede7078832c9120875eb24c1491