### PR TITLE
Refactor turn summary layout

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 # TODO / Open Tasks
 
 ## Completed
+- Refactor end-of-turn summary UI: relocated turn statistics into the score card, collapsed the detailed breakdown/time graphs, added colored toggle blocks for each word, and surfaced the time-between-word graph.
 - Add toggleable score-to-target regime with configurable goal in Settings and wire it into game flow.
 - Gate bundled deck import to first run (DB empty) to avoid re-imports.
 - Dedupe deck imports by replacing words per deck on import.
@@ -37,7 +38,6 @@
 
 
 ## Backlog
-- Refactor end-of-turn summary UI: relocate turn statistics, collapse detailed breakdown/time graph (taller), per-word blocks with colored backgrounds acting as correct/incorrect toggles, and show time-between-word graph.
 - Refactor game image loading pipeline for robustness/performance. Add support for deck image as url, download it at deck import and cache it if neccesary.
 - Tests:
   - Repository: verify re-import of the same deck does not duplicate words (and that updated decks replace content).

--- a/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,6 +34,7 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -95,8 +98,7 @@ fun roundSummaryScreen(vm: MainViewModel, s: GameState.TurnFinished, settings: S
                 deltaColor = deltaColor,
             )
         }
-        item { scoreboardCard(scores = s.scores) }
-        item { turnSummaryStatsCard(stats = stats) }
+        item { scoreboardCard(scores = s.scores, stats = stats) }
         item {
             timelineCard(
                 timeline = timeline,
@@ -115,6 +117,7 @@ fun roundSummaryScreen(vm: MainViewModel, s: GameState.TurnFinished, settings: S
 @Composable
 private fun scoreboardCard(
     scores: Map<String, Int>,
+    stats: TurnSummaryStats,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -122,33 +125,22 @@ private fun scoreboardCard(
         shape = RoundedCornerShape(24.dp),
         tonalElevation = 2.dp,
     ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp)) {
-            scoreboard(scores)
-        }
-    }
-}
-
-@Composable
-private fun turnSummaryStatsCard(
-    stats: TurnSummaryStats,
-    modifier: Modifier = Modifier,
-) {
-    ElevatedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(24.dp),
-    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp, vertical = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            Text(
-                text = stringResource(R.string.turn_summary_stats_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            turnSummaryStatsRow(stats = stats)
+            scoreboard(scores)
+            HorizontalDivider()
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = stringResource(R.string.turn_summary_stats_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                turnSummaryStatsRow(stats = stats)
+            }
         }
     }
 }
@@ -201,7 +193,8 @@ private fun timelineCard(
                     title = stringResource(R.string.timeline_graphs_title),
                     subtitle = stringResource(R.string.timeline_graphs_subtitle),
                     modifier = Modifier.padding(horizontal = 20.dp),
-                    contentArrangement = Arrangement.spacedBy(16.dp),
+                    initiallyExpanded = false,
+                    contentArrangement = Arrangement.spacedBy(20.dp),
                 ) {
                     scoreProgressGraph(
                         events = timeline.events,
@@ -216,6 +209,7 @@ private fun timelineCard(
                     title = stringResource(R.string.timeline_breakdown_title),
                     subtitle = stringResource(R.string.timeline_breakdown_subtitle),
                     modifier = Modifier.padding(horizontal = 20.dp),
+                    initiallyExpanded = false,
                     contentArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     timeline.segments.forEach { segment ->
@@ -580,7 +574,7 @@ private fun scoreProgressGraph(events: List<TimelineEvent>, modifier: Modifier =
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(180.dp)
+                .height(220.dp)
                 .clip(RoundedCornerShape(12.dp))
                 .background(colors.surfaceVariant.copy(alpha = 0.6f))
                 .padding(horizontal = 12.dp, vertical = 12.dp),
@@ -677,7 +671,7 @@ private fun timeBetweenWordsGraph(events: List<TimelineEvent>, modifier: Modifie
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(180.dp)
+                .height(220.dp)
                 .clip(RoundedCornerShape(12.dp))
                 .background(colors.surfaceVariant.copy(alpha = 0.6f))
                 .padding(horizontal = 12.dp, vertical = 12.dp),
@@ -733,11 +727,7 @@ private fun ExpandableSection(
         stringResource(R.string.timeline_section_state_collapsed)
     }
     Surface(
-        modifier = modifier
-            .fillMaxWidth()
-            .semantics { stateDescription = stateLabel },
-        onClick = { expanded = !expanded },
-        role = Role.Button,
+        modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(20.dp),
         color = colors.surfaceVariant.copy(alpha = if (expanded) 0.6f else 0.45f),
         tonalElevation = if (expanded) 2.dp else 0.dp,
@@ -745,6 +735,8 @@ private fun ExpandableSection(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .semantics { stateDescription = stateLabel }
+                .clickable(role = Role.Button) { expanded = !expanded }
                 .padding(horizontal = 16.dp, vertical = 14.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -885,6 +877,7 @@ private fun timelineEventBlock(
         TimelineSegmentType.SKIP -> colors.errorContainer to colors.onErrorContainer
         TimelineSegmentType.PENDING -> colors.surfaceVariant to colors.onSurface
     }
+    val borderColor = timelineColor(event.type).copy(alpha = 0.4f)
     val supportColor = contentColor.copy(alpha = 0.8f)
     val timeLabel = if (event.elapsedMillis <= 0L) {
         stringResource(R.string.timeline_elapsed_time_start)
@@ -906,20 +899,20 @@ private fun timelineEventBlock(
     Surface(
         modifier = modifier
             .fillMaxWidth()
-            .semantics { stateDescription = stateLabel },
+            .border(BorderStroke(1.dp, borderColor), RoundedCornerShape(20.dp)),
+        shape = RoundedCornerShape(20.dp),
         color = containerColor,
         contentColor = contentColor,
-        shape = RoundedCornerShape(20.dp),
         tonalElevation = 0.dp,
-        onClick = {
-            val target = !event.outcome.correct
-            onToggle(target)
-        },
-        role = Role.Button,
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .semantics { stateDescription = stateLabel }
+                .clickable(role = Role.Button) {
+                    val target = !event.outcome.correct
+                    onToggle(target)
+                }
                 .padding(horizontal = 16.dp, vertical = 14.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
@@ -896,11 +896,13 @@ private fun timelineEventBlock(
         else -> Icons.Filled.Schedule
     }
 
+    val blockShape = RoundedCornerShape(20.dp)
+
     Surface(
         modifier = modifier
             .fillMaxWidth()
-            .border(BorderStroke(1.dp, borderColor), RoundedCornerShape(20.dp)),
-        shape = RoundedCornerShape(20.dp),
+            .border(BorderStroke(1.dp, borderColor), blockShape),
+        shape = blockShape,
         color = containerColor,
         contentColor = contentColor,
         tonalElevation = 0.dp,


### PR DESCRIPTION
## Summary
- Combine the score totals and per-turn statistics into a single summary card with a divider for quicker scanning
- Keep the timeline breakdown collapsed by default, enlarge the graphs, and add visual borders/clickable toggles to each word event
- Mark the end-of-turn summary refactor task as completed in the TODO list

## Testing
- ./gradlew spotlessCheck --console=plain
- ./gradlew detekt --console=plain *(reports existing warnings in unrelated files)*
- ./gradlew :domain:test :data:test :app:testDebugUnitTest --console=plain
- ./gradlew :app:assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_b_68cef5be5d88832cae411fb0a4a458dc