### PR TITLE
Support remote deck cover images and caching

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,11 +34,11 @@
 - Engine: add property-like tests for multi-team rotation and cumulative scoring across many turns.
 - Deck details: ensure recent words pull from games played with the selected deck.
 - Update History screen: hide filters/stats by default, add Reset History action, and align detailed game view with end-of-turn summary layout.
+- Refactor game image loading pipeline for robustness/performance. Add support for deck image as url, download it at deck import and cache it if neccesary.
 
 
 ## Backlog
 - Refactor end-of-turn summary UI: relocate turn statistics, collapse detailed breakdown/time graph (taller), per-word blocks with colored backgrounds acting as correct/incorrect toggles, and show time-between-word graph.
-- Refactor game image loading pipeline for robustness/performance. Add support for deck image as url, download it at deck import and cache it if neccesary.
 - Tests:
   - Repository: verify re-import of the same deck does not duplicate words (and that updated decks replace content).
   - App-layer: verify last-turn outcomes are persisted when match ends (target reached or timer with no words left).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,4 +105,6 @@ dependencies {
 
     testImplementation(libs.bundles.test.unit)
     testImplementation(libs.okhttp)
+    testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.okhttp.tls)
 }

--- a/app/src/main/java/com/example/alias/DeckManager.kt
+++ b/app/src/main/java/com/example/alias/DeckManager.kt
@@ -1,7 +1,6 @@
 package com.example.alias
 
 import android.content.Context
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Base64
 import com.example.alias.data.DeckRepository
@@ -13,6 +12,7 @@ import com.example.alias.data.db.WordClassCount
 import com.example.alias.data.db.WordDao
 import com.example.alias.data.download.PackDownloader
 import com.example.alias.data.pack.PackParser
+import com.example.alias.data.pack.PackValidator
 import com.example.alias.data.pack.ParsedPack
 import com.example.alias.data.settings.Settings
 import com.example.alias.data.settings.SettingsRepository
@@ -537,29 +537,71 @@ class DeckManager
         }
 
         private suspend fun sanitizeCoverImage(pack: ParsedPack): SanitizedPack {
-            val coverError = withContext(Dispatchers.IO) {
-                pack.deck.coverImageBase64?.let { encoded ->
-                    try {
-                        val decoded = Base64.decode(encoded, Base64.DEFAULT)
-                        require(decoded.isNotEmpty()) { "Cover image is empty" }
-                        val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-                        BitmapFactory.decodeByteArray(decoded, 0, decoded.size, opts)
-                        require(opts.outWidth > 0 && opts.outHeight > 0) { "Cover image has invalid dimensions" }
-                        null
-                    } catch (c: CancellationException) {
-                        throw c
-                    } catch (t: Throwable) {
-                        logger.error("Failed to decode deck cover image for ${pack.deck.id}", t)
-                        t
+            var coverImageError: Throwable? = null
+            val sanitizedDeck = when {
+                pack.coverImageUrl != null -> {
+                    val coverUrl = checkNotNull(pack.coverImageUrl)
+                    val result = fetchCoverImageFromUrl(coverUrl)
+                    if (result.isSuccess) {
+                        pack.deck.copy(coverImageBase64 = result.getOrThrow())
+                    } else {
+                        val error = result.exceptionOrNull()
+                        if (error is CancellationException) throw error
+                        val wrapped = wrapCoverImageError("Failed to download cover image", error)
+                        logger.error(
+                            "Failed to download deck cover image for ${pack.deck.id}",
+                            wrapped,
+                        )
+                        coverImageError = wrapped
+                        pack.deck.copy(coverImageBase64 = null)
                     }
                 }
+                pack.deck.coverImageBase64 != null -> {
+                    val result = withContext(Dispatchers.IO) {
+                        runCatching {
+                            val decoded = Base64.decode(pack.deck.coverImageBase64, Base64.DEFAULT)
+                            PackValidator.validateCoverImageBytes(decoded)
+                        }
+                    }
+                    if (result.isSuccess) {
+                        pack.deck.copy(coverImageBase64 = result.getOrThrow())
+                    } else {
+                        val error = result.exceptionOrNull()
+                        if (error is CancellationException) throw error
+                        logger.error("Failed to decode deck cover image for ${pack.deck.id}", error)
+                        coverImageError = error
+                        pack.deck.copy(coverImageBase64 = null)
+                    }
+                }
+                else -> pack.deck
             }
-            val sanitized = if (coverError != null) {
-                pack.copy(deck = pack.deck.copy(coverImageBase64 = null))
-            } else {
-                pack
+            val sanitized = pack.copy(deck = sanitizedDeck, coverImageUrl = null)
+            return SanitizedPack(sanitized, coverImageError)
+        }
+
+        private suspend fun fetchCoverImageFromUrl(url: String): Result<String> {
+            return withContext(Dispatchers.IO) {
+                runCatching {
+                    val bytes = downloader.download(
+                        url.trim(),
+                        expectedSha256 = null,
+                        maxBytes = PackValidator.MAX_COVER_IMAGE_BYTES.toLong(),
+                    )
+                    PackValidator.validateCoverImageBytes(bytes)
+                }
             }
-            return SanitizedPack(sanitized, coverError)
+        }
+
+        private fun wrapCoverImageError(message: String, error: Throwable?): Throwable {
+            if (error == null) {
+                return IllegalArgumentException(message)
+            }
+            if (error is IllegalArgumentException &&
+                error.message?.contains("cover image", ignoreCase = true) == true
+            ) {
+                return error
+            }
+            return IllegalArgumentException(message, error)
         }
 
         private suspend fun parseAndSanitizePack(content: String, isBundledAsset: Boolean = false): SanitizedPack {
@@ -580,12 +622,12 @@ class DeckManager
             return try {
                 val root = bundleJson.parseToJsonElement(content).jsonObject
                 val deck = root["deck"]?.jsonObject ?: return null
-                if (!deck.containsKey("coverImage")) {
+                if (!deck.containsKey("coverImage") && !deck.containsKey("coverImageUrl")) {
                     return null
                 }
                 val sanitizedDeck = buildJsonObject {
                     deck.forEach { (key, value) ->
-                        if (key != "coverImage") {
+                        if (key != "coverImage" && key != "coverImageUrl") {
                             put(key, value)
                         }
                     }

--- a/app/src/main/java/com/example/alias/ui/decks/DeckCoverImageLoader.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DeckCoverImageLoader.kt
@@ -1,0 +1,64 @@
+package com.example.alias.ui.decks
+
+import android.graphics.BitmapFactory
+import android.util.Base64
+import android.util.LruCache
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.security.MessageDigest
+import kotlin.text.Charsets
+
+private data class DeckCoverCacheEntry(val bitmap: ImageBitmap?)
+
+object DeckCoverImageLoader {
+    private const val CACHE_SIZE = 24
+    private val cache = object : LruCache<String, DeckCoverCacheEntry>(CACHE_SIZE) {}
+    private val mutex = Mutex()
+
+    suspend fun load(base64: String): ImageBitmap? {
+        val key = cacheKey(base64)
+        mutex.withLock {
+            cache.get(key)?.let { entry ->
+                return entry.bitmap
+            }
+        }
+        val bitmap = withContext(Dispatchers.IO) {
+            runCatching {
+                val decoded = Base64.decode(base64, Base64.DEFAULT)
+                if (decoded.isEmpty()) {
+                    null
+                } else {
+                    BitmapFactory.decodeByteArray(decoded, 0, decoded.size)?.asImageBitmap()
+                }
+            }.getOrNull()
+        }
+        mutex.withLock {
+            cache.put(key, DeckCoverCacheEntry(bitmap))
+        }
+        return bitmap
+    }
+
+    suspend fun clear() {
+        mutex.withLock { cache.evictAll() }
+    }
+
+    private fun cacheKey(base64: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashed = digest.digest(base64.toByteArray(Charsets.UTF_8))
+        return hashed.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+}
+
+@Composable
+fun rememberDeckCoverImage(base64: String?): ImageBitmap? {
+    val imageState = produceState<ImageBitmap?>(initialValue = null, base64) {
+        value = base64?.let { DeckCoverImageLoader.load(it) }
+    }
+    return imageState.value
+}

--- a/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/decks/DecksScreen.kt
@@ -1,7 +1,5 @@
 package com.example.alias.ui.decks
 
-import android.graphics.BitmapFactory
-import android.util.Base64
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -62,7 +60,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -71,8 +68,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -81,8 +76,6 @@ import androidx.compose.ui.unit.dp
 import com.example.alias.MainViewModel
 import com.example.alias.R
 import com.example.alias.data.db.DeckEntity
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import java.util.Locale
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
@@ -628,25 +621,6 @@ fun rememberDeckCoverBrush(deckId: String): Brush {
         listOf(DeckCoverPalette[baseIndex], DeckCoverPalette[nextIndex])
     }
     return remember(colors) { Brush.linearGradient(colors) }
-}
-
-@Composable
-fun rememberDeckCoverImage(base64: String?): ImageBitmap? {
-    val imageState = produceState<ImageBitmap?>(initialValue = null, base64) {
-        value = base64?.let { encoded ->
-            withContext(Dispatchers.IO) {
-                runCatching {
-                    val bytes = Base64.decode(encoded, Base64.DEFAULT)
-                    if (bytes.isEmpty()) {
-                        null
-                    } else {
-                        BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.asImageBitmap()
-                    }
-                }.getOrNull()
-            }
-        }
-    }
-    return imageState.value
 }
 
 @Composable

--- a/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -735,9 +736,8 @@ private fun ExpandableSection(
     Surface(
         modifier = modifier
             .fillMaxWidth()
-            .semantics { stateDescription = stateLabel },
-        onClick = { expanded = !expanded },
-        role = Role.Button,
+            .semantics { stateDescription = stateLabel }
+            .clickable(role = Role.Button) { expanded = !expanded },
         shape = RoundedCornerShape(20.dp),
         color = colors.surfaceVariant.copy(alpha = if (expanded) 0.6f else 0.45f),
         tonalElevation = if (expanded) 2.dp else 0.dp,
@@ -906,16 +906,15 @@ private fun timelineEventBlock(
     Surface(
         modifier = modifier
             .fillMaxWidth()
-            .semantics { stateDescription = stateLabel },
+            .semantics { stateDescription = stateLabel }
+            .clickable(role = Role.Button) {
+                val target = !event.outcome.correct
+                onToggle(target)
+            },
         color = containerColor,
         contentColor = contentColor,
         shape = RoundedCornerShape(20.dp),
         tonalElevation = 0.dp,
-        onClick = {
-            val target = !event.outcome.correct
-            onToggle(target)
-        },
-        role = Role.Button,
     ) {
         Row(
             modifier = Modifier

--- a/data/src/main/java/com/example/alias/data/pack/PackValidator.kt
+++ b/data/src/main/java/com/example/alias/data/pack/PackValidator.kt
@@ -10,8 +10,9 @@ import java.util.Locale
 object PackValidator {
     const val MULTI_LANGUAGE_TAG = "mul"
     private const val MAX_WORDS = 200_000
-    private const val MAX_COVER_IMAGE_BYTES = 256_000
+    const val MAX_COVER_IMAGE_BYTES = 256_000
     private const val MAX_COVER_IMAGE_DIMENSION = 2_048
+    private const val MAX_COVER_IMAGE_URL_LENGTH = 2_048
     private val ID_REGEX = Regex("^[a-z0-9_-]{1,64}$")
     private val LANG_REGEX = Regex("^[A-Za-z]{2,8}(-[A-Za-z0-9]{1,8})*$")
     private val base64Encoder = Base64.getEncoder()
@@ -37,6 +38,27 @@ object PackValidator {
         return normalizeCoverImage(coverImageBase64)
     }
 
+    fun normalizeCoverImageUrl(coverImageUrl: String?): String? {
+        if (coverImageUrl == null) {
+            return null
+        }
+        val trimmed = coverImageUrl.trim()
+        if (trimmed.isEmpty()) {
+            return null
+        }
+        require(trimmed.length <= MAX_COVER_IMAGE_URL_LENGTH) { "Cover image URL too long" }
+        val uri = try {
+            java.net.URI(trimmed)
+        } catch (error: Exception) {
+            throw IllegalArgumentException("Invalid cover image URL", error)
+        }
+        require(uri.isAbsolute) { "Cover image URL must be absolute" }
+        require(uri.scheme.equals("https", ignoreCase = true)) { "Cover image URL must use HTTPS" }
+        require(!uri.host.isNullOrBlank()) { "Cover image URL missing host" }
+        require(uri.userInfo == null) { "Cover image URL must not contain credentials" }
+        return uri.toString()
+    }
+
     fun normalizeLanguageTag(language: String): String {
         val trimmed = language.trim()
         require(LANG_REGEX.matches(trimmed)) { "Invalid language tag" }
@@ -57,15 +79,19 @@ object PackValidator {
         } catch (error: IllegalArgumentException) {
             throw IllegalArgumentException("Invalid cover image encoding", error)
         }
-        require(decoded.isNotEmpty()) { "Cover image is empty" }
-        require(decoded.size <= MAX_COVER_IMAGE_BYTES) { "Cover image too large" }
-        val (width, height) = decodeImageDimensions(decoded)
+        return validateCoverImageBytes(decoded)
+    }
+
+    fun validateCoverImageBytes(data: ByteArray): String {
+        require(data.isNotEmpty()) { "Cover image is empty" }
+        require(data.size <= MAX_COVER_IMAGE_BYTES) { "Cover image too large" }
+        val (width, height) = decodeImageDimensions(data)
             ?: throw IllegalArgumentException("Cover image has invalid dimensions")
         require(width > 0 && height > 0) { "Cover image has invalid dimensions" }
         require(width <= MAX_COVER_IMAGE_DIMENSION && height <= MAX_COVER_IMAGE_DIMENSION) {
             "Cover image dimensions too large"
         }
-        return base64Encoder.encodeToString(decoded)
+        return base64Encoder.encodeToString(data)
     }
 
     private fun decodeImageDimensions(data: ByteArray): Pair<Int, Int>? {


### PR DESCRIPTION
## Summary
- allow deck packs to provide `coverImageUrl` entries and validate HTTPS URLs alongside existing cover image rules
- download and sanitize remote deck covers during import, add a reusable bitmap cache for Compose cover rendering, and adjust clickable surfaces
- extend cover image unit tests, add a remote cover import test with MockWebServer, and mark the TODO item complete

## Testing
- ./gradlew spotlessApply --no-daemon --console=plain -q
- ./gradlew :data:test :app:testDebugUnitTest --no-daemon --console=plain -q

------
https://chatgpt.com/codex/tasks/task_b_68cef5c94048832c85dfb585c42f5f36