### PR TITLE
Fix stale enabled deck IDs after permanently deleting imported decks

### DIFF
--- a/app/src/main/java/com/example/alias/DeckManager.kt
+++ b/app/src/main/java/com/example/alias/DeckManager.kt
@@ -425,8 +425,6 @@ class DeckManager
         }
 
         suspend fun deleteDeck(deck: DeckEntity): DeleteDeckResult {
-            val settingsSnapshot = settingsRepository.settings.first()
-            val updatedIds = settingsSnapshot.enabledDeckIds - deck.id
             val isBundledDeck = deck.isOfficial
             val result = runCatching {
                 withContext(Dispatchers.IO) {
@@ -436,13 +434,11 @@ class DeckManager
                         deckRepository.deleteDeck(deck.id)
                     }
                 }
+                settingsRepository.removeEnabledDeckId(deck.id)
             }
             if (result.isFailure) {
                 val error = result.exceptionOrNull()?.message ?: "Unknown error"
                 return DeleteDeckResult.Failure(error)
-            }
-            if (updatedIds != settingsSnapshot.enabledDeckIds) {
-                settingsRepository.setEnabledDeckIds(updatedIds)
             }
             val message = if (isBundledDeck) {
                 "Hidden deck: ${deck.name}"
@@ -452,15 +448,11 @@ class DeckManager
             return DeleteDeckResult.Success(message)
         }
 
-        suspend fun permanentlyDeleteImportedDeck(deck: DeckEntity): Result<Unit> {
-            return runCatching {
-                val settingsSnapshot = settingsRepository.settings.first()
+        suspend fun permanentlyDeleteImportedDeck(deck: DeckEntity): Result<Unit> =
+            runCatching {
                 withContext(Dispatchers.IO) { deckRepository.deleteDeck(deck.id) }
-                if (settingsSnapshot.enabledDeckIds.contains(deck.id)) {
-                    settingsRepository.setEnabledDeckIds(settingsSnapshot.enabledDeckIds - deck.id)
-                }
+                settingsRepository.removeEnabledDeckId(deck.id)
             }
-        }
 
         suspend fun restoreDeletedBundledDeck(deckId: String): Result<Unit> {
             return runCatching {

--- a/app/src/main/java/com/example/alias/DeckManager.kt
+++ b/app/src/main/java/com/example/alias/DeckManager.kt
@@ -454,7 +454,11 @@ class DeckManager
 
         suspend fun permanentlyDeleteImportedDeck(deck: DeckEntity): Result<Unit> {
             return runCatching {
+                val settingsSnapshot = settingsRepository.settings.first()
                 withContext(Dispatchers.IO) { deckRepository.deleteDeck(deck.id) }
+                if (settingsSnapshot.enabledDeckIds.contains(deck.id)) {
+                    settingsRepository.setEnabledDeckIds(settingsSnapshot.enabledDeckIds - deck.id)
+                }
             }
         }
 

--- a/app/src/test/java/com/example/alias/DeckManagerTest.kt
+++ b/app/src/test/java/com/example/alias/DeckManagerTest.kt
@@ -566,6 +566,10 @@ class DeckManagerTest {
             flow.value = flow.value.copy(enabledDeckIds = ids)
         }
 
+        override suspend fun removeEnabledDeckId(deckId: String) {
+            flow.value = flow.value.copy(enabledDeckIds = flow.value.enabledDeckIds - deckId)
+        }
+
         override suspend fun setDeckLanguagesFilter(languages: Set<String>) {
             flow.value = flow.value.copy(selectedDeckLanguages = languages)
         }

--- a/app/src/test/java/com/example/alias/SettingsControllerTest.kt
+++ b/app/src/test/java/com/example/alias/SettingsControllerTest.kt
@@ -77,6 +77,9 @@ class SettingsControllerTest {
         override suspend fun setEnabledDeckIds(ids: Set<String>) {
             state.value = state.value.copy(enabledDeckIds = ids)
         }
+        override suspend fun removeEnabledDeckId(deckId: String) {
+            state.value = state.value.copy(enabledDeckIds = state.value.enabledDeckIds - deckId)
+        }
         override suspend fun setDeckLanguagesFilter(languages: Set<String>) {
             state.value = state.value.copy(selectedDeckLanguages = languages)
         }

--- a/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
+++ b/data/src/main/java/com/example/alias/data/settings/SettingsRepository.kt
@@ -41,6 +41,7 @@ interface SettingsRepository {
     suspend fun updateSkipPolicy(maxSkips: Int, penaltyPerSkip: Int)
     suspend fun updatePunishSkips(value: Boolean)
     suspend fun setEnabledDeckIds(ids: Set<String>)
+    suspend fun removeEnabledDeckId(deckId: String)
     suspend fun updateAllowNSFW(value: Boolean)
     suspend fun updateStemmingEnabled(value: Boolean)
     suspend fun updateHapticsEnabled(value: Boolean)
@@ -172,6 +173,15 @@ class SettingsRepositoryImpl(
 
     override suspend fun setEnabledDeckIds(ids: Set<String>) {
         dataStore.edit { it[Keys.ENABLED_DECK_IDS] = ids }
+    }
+
+    override suspend fun removeEnabledDeckId(deckId: String) {
+        dataStore.edit { prefs ->
+            val current = prefs[Keys.ENABLED_DECK_IDS] ?: emptySet()
+            if (current.contains(deckId)) {
+                prefs[Keys.ENABLED_DECK_IDS] = current - deckId
+            }
+        }
     }
 
     override suspend fun setDeckLanguagesFilter(languages: Set<String>) {

--- a/data/src/test/java/com/example/alias/data/download/PackDownloaderTest.kt
+++ b/data/src/test/java/com/example/alias/data/download/PackDownloaderTest.kt
@@ -27,6 +27,7 @@ private class FakeSettingsRepo(origins: Set<String>) : SettingsRepository {
     override suspend fun updateSkipPolicy(maxSkips: Int, penaltyPerSkip: Int) = Unit
     override suspend fun updatePunishSkips(value: Boolean) = Unit
     override suspend fun setEnabledDeckIds(ids: Set<String>) = Unit
+    override suspend fun removeEnabledDeckId(deckId: String) = Unit
     override suspend fun setDeckLanguagesFilter(languages: Set<String>) = Unit
     override suspend fun updateAllowNSFW(value: Boolean) = Unit
     override suspend fun updateStemmingEnabled(value: Boolean) = Unit


### PR DESCRIPTION
## Summary
- ensure permanently deleting an imported deck also removes its id from the enabled deck set
- avoid stale enabled deck references that caused word loads to include deleted decks

## Testing
- ./gradlew --console=plain spotlessCheck *(fails: ktlint parse error in app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt unrelated to this change)*
- ./gradlew --console=plain detekt *(fails: detekt NPE analyzing app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt unrelated to this change)*
- ./gradlew --console=plain :domain:test
- ./gradlew --console=plain :data:test
- ./gradlew --console=plain :app:testDebugUnitTest *(fails: Kotlin compilation error in app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt unrelated to this change)*


------
https://chatgpt.com/codex/tasks/task_b_68cf13698f3c832c94951398a595c6d9