### PR TITLE
Disable detekt auto-correction

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ subprojects {
 
         // ✅ Configure reports on the TASK, not the extension (fixes deprecation warning)
         tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-            autoCorrect = true
+            autoCorrect = false
             ignoreFailures = true
             reports {
                 html.required.set(true)
@@ -75,7 +75,7 @@ allprojects {
         configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
             config.setFrom(files("$rootDir/detekt.yml"))
             buildUponDefaultConfig = true
-            autoCorrect = true
+            autoCorrect = false
             parallel = true
         }
     }
@@ -84,7 +84,7 @@ allprojects {
 detekt {
     buildUponDefaultConfig = true
     allRules = false
-    autoCorrect = true
+    autoCorrect = false
     parallel = true
     ignoreFailures = true
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -130,10 +130,10 @@ comments:
 formatting:
   active: true
   android: true
-  autoCorrect: true
+  autoCorrect: false
   ImportOrdering:
     active: true
-    autoCorrect: true
+    autoCorrect: false
   MaximumLineLength:
     active: true
     maxLineLength: 120


### PR DESCRIPTION
## Summary
- disable auto-correction on all detekt tasks and the root extension
- turn off detekt-formatting auto-correct so it only reports style issues

## Testing
- ./gradlew detekt --console=plain --quiet

------
https://chatgpt.com/codex/tasks/task_b_68cf3055ee4c832c9b074d9e03cac465