### PR TITLE
Disable max words input when score goal is active

### DIFF
--- a/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
@@ -441,6 +441,12 @@ private fun matchRulesTab(
                         label = { Text(stringResource(R.string.target_words_label)) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
+                        enabled = !state.scoreTargetEnabled,
+                        supportingText = {
+                            if (state.scoreTargetEnabled) {
+                                Text(stringResource(R.string.target_words_disabled_supporting_text))
+                            }
+                        },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     )
                     Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/settings/SettingsScreen.kt
@@ -442,11 +442,9 @@ private fun matchRulesTab(
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         enabled = !state.scoreTargetEnabled,
-                        supportingText = {
-                            if (state.scoreTargetEnabled) {
-                                Text(stringResource(R.string.target_words_disabled_supporting_text))
-                            }
-                        },
+                        supportingText = if (state.scoreTargetEnabled) {
+                            { Text(stringResource(R.string.target_words_disabled_supporting_text)) }
+                        } else null,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     )
                     Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -271,6 +271,7 @@
     <string name="round_and_goals">Раунд и цели</string>
     <string name="round_seconds_label">Время раунда</string>
     <string name="target_words_label">Цель по словам</string>
+    <string name="target_words_disabled_supporting_text">Недоступно, если включена цель по очкам.</string>
     <string name="score_target_toggle_label">Использовать цель по очкам</string>
     <string name="target_score_label">Цель по очкам</string>
     <string name="skips_section">Пропуски</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,7 @@
     <string name="round_and_goals">Round &amp; Goals</string>
     <string name="round_seconds_label">Round seconds</string>
     <string name="target_words_label">Max words</string>
+    <string name="target_words_disabled_supporting_text">Disabled when using a score goal.</string>
     <string name="score_target_toggle_label">Use score goal</string>
     <string name="target_score_label">Target score</string>
     <string name="skips_section">Skips</string>


### PR DESCRIPTION
## Summary
- disable the Max words field when a score goal is selected and show inline guidance about why it is unavailable
- add English and Russian helper strings that clarify the Max words field is disabled when a score goal is active

## Testing
- `./gradlew --console=plain spotlessCheck detekt :domain:test :data:test :app:testDebugUnitTest :app:assembleDebug` *(fails: :data:parseDebugLocalResources cannot create R-def.txt because the Android build tooling is unavailable in this environment)*
- `./gradlew --console=plain spotlessCheck detekt :domain:test :data:test :app:testDebugUnitTest` *(fails: :app:spotlessKotlinCheck reports existing formatting violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_b_68cf336cf6cc832ca1f5056857f65f52