### PR TITLE
Filter hidden decks from home favorites

### DIFF
--- a/app/src/main/java/com/example/alias/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/home/HomeScreen.kt
@@ -235,13 +235,13 @@ private fun homeHeroSection(
             }
         }
     }
-    val favoriteDecks = remember(settings.enabledDeckIds, decks) {
+    val visibleEnabledDecks = remember(settings.enabledDeckIds, decks) {
         val enabled = settings.enabledDeckIds
         decks.filter { enabled.contains(it.id) }
             .sortedBy { it.name }
-            .take(3)
     }
-    val extraDecks = (settings.enabledDeckIds.size - favoriteDecks.size).coerceAtLeast(0)
+    val favoriteDecks = visibleEnabledDecks.take(3)
+    val extraDecks = (visibleEnabledDecks.size - favoriteDecks.size).coerceAtLeast(0)
     val highlight = recentHistory.firstOrNull()
     val highlightText = when {
         highlight == null -> stringResource(R.string.home_highlight_empty)


### PR DESCRIPTION
## Summary
- filter the home hero's favorite list to decks that are still available
- base the extra favorites count on the filtered list so hidden decks are not counted

## Testing
- ./gradlew --console plain detekt
- ./gradlew --console plain spotlessCheck *(fails: pre-existing formatting violations in SettingsScreen.kt)*

------
https://chatgpt.com/codex/tasks/task_b_68cfbdcac974832ca902a0f7525290c5