### PR TITLE
Refactor match over screen

### DIFF
--- a/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
@@ -668,25 +668,16 @@ fun gameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
             roundSummaryScreen(vm = vm, s = s, settings = settings)
         }
         is GameState.MatchFinished -> {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    stringResource(R.string.match_finished_message),
-                    style = MaterialTheme.typography.headlineSmall,
-                )
-                scoreboard(s.scores)
-                Text(stringResource(R.string.start_new_match))
-                Button(onClick = {
+            matchOverScreen(
+                scores = s.scores,
+                onRestartMatch = {
                     if (settings.hapticsEnabled) {
                         val effect = VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK)
                         vibrator?.vibrate(effect)
                     }
                     vm.restartMatch()
-                }) { Text(stringResource(R.string.restart_match)) }
-            }
+                },
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/GameScreen.kt
@@ -668,7 +668,7 @@ fun gameScreen(vm: MainViewModel, engine: GameEngine, settings: Settings) {
             roundSummaryScreen(vm = vm, s = s, settings = settings)
         }
         is GameState.MatchFinished -> {
-            matchOverScreen(
+            MatchOverScreen(
                 scores = s.scores,
                 onRestartMatch = {
                     if (settings.hapticsEnabled) {

--- a/app/src/main/java/com/example/alias/ui/game/MatchOverScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/MatchOverScreen.kt
@@ -1,0 +1,48 @@
+package com.example.alias.ui.game
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.alias.R
+import com.example.alias.ui.common.scoreboard
+
+@Composable
+fun matchOverScreen(
+    scores: Map<String, Int>,
+    onRestartMatch: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.match_finished_message),
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        scoreboard(scores)
+        Text(
+            text = stringResource(R.string.start_new_match),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Button(onClick = onRestartMatch) {
+            Text(stringResource(R.string.restart_match))
+        }
+    }
+}

--- a/app/src/main/java/com/example/alias/ui/game/MatchOverScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/MatchOverScreen.kt
@@ -17,7 +17,7 @@ import com.example.alias.R
 import com.example.alias.ui.common.scoreboard
 
 @Composable
-fun matchOverScreen(
+fun MatchOverScreen(
     scores: Map<String, Int>,
     onRestartMatch: () -> Unit,
     modifier: Modifier = Modifier,


### PR DESCRIPTION
## Summary
- extract the match finished UI into a dedicated `matchOverScreen` composable
- invoke the new composable from the game screen so restart handling stays centralized

## Testing
- ./gradlew spotlessCheck detekt --console=plain *(fails: existing spotless violations in :data:spotlessKotlinCheck)*

------
https://chatgpt.com/codex/tasks/task_b_68cfc0a5cbc8832cb308224a8e52adb6