### PR TITLE
Refactor history screen to group games and turns

### DIFF
--- a/app/src/main/java/com/example/alias/ui/HistoryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/HistoryScreen.kt
@@ -3,8 +3,10 @@ package com.example.alias.ui
 import android.text.format.DateUtils
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,6 +27,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
@@ -55,17 +58,25 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.example.alias.R
 import com.example.alias.data.db.TurnHistoryEntity
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import kotlin.math.roundToInt
 
 private const val SPARKLINE_RECENT_ENTRIES_COUNT = 12
 private val SPARKLINE_DOT_RADIUS = 4.dp
 private const val SPARKLINE_STROKE_WIDTH = 4f
+private const val TURN_BREAK_THRESHOLD_MILLIS = 3 * 60_000L
+private const val GAME_BREAK_THRESHOLD_MILLIS = 20 * 60_000L
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -113,17 +124,20 @@ fun historyScreen(
     val filterListener = rememberHistoryFilterListener(filterState)
     var headerExpanded by rememberSaveable { mutableStateOf(false) }
 
-    val filtered = remember(
-        sorted,
+    val games = remember(sorted) { groupHistoryIntoGames(sorted) }
+    val filteredGames = remember(
+        games,
         filterState.selectedTeam,
         filterState.selectedDifficulty,
         filterState.selectedResult,
     ) {
-        sorted.filter { entry ->
-            val matchesTeam = filterState.selectedTeam == null || entry.team == filterState.selectedTeam
-            val matchesDifficulty =
-                filterState.selectedDifficulty == null || entry.difficulty == filterState.selectedDifficulty
-            val matchesResult = when (filterState.selectedResult) {
+        val selectedTeam = filterState.selectedTeam
+        val selectedDifficulty = filterState.selectedDifficulty
+        val selectedResult = filterState.selectedResult
+        val predicate: (TurnHistoryEntity) -> Boolean = { entry ->
+            val matchesTeam = selectedTeam == null || entry.team == selectedTeam
+            val matchesDifficulty = selectedDifficulty == null || entry.difficulty == selectedDifficulty
+            val matchesResult = when (selectedResult) {
                 ResultFilter.All -> true
                 ResultFilter.Correct -> entry.correct
                 ResultFilter.Skipped -> !entry.correct && entry.skipped
@@ -131,6 +145,7 @@ fun historyScreen(
             }
             matchesTeam && matchesDifficulty && matchesResult
         }
+        games.mapNotNull { it.filter(predicate) }
     }
 
     Column(
@@ -189,14 +204,14 @@ fun historyScreen(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(stringResource(R.string.history_section_recent_turns), style = MaterialTheme.typography.titleMedium)
+            Text(stringResource(R.string.history_section_recent_games), style = MaterialTheme.typography.titleMedium)
             Text(
-                text = stringResource(R.string.history_recent_count, filtered.size, sorted.size),
+                text = stringResource(R.string.history_recent_count, filteredGames.size, games.size),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        if (filtered.isEmpty()) {
+        if (filteredGames.isEmpty()) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -213,8 +228,8 @@ fun historyScreen(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                items(filtered) { entry ->
-                    historyEntryCard(entry = entry)
+                items(filteredGames, key = { it.id }) { game ->
+                    historyGameCard(game = game)
                 }
             }
         }
@@ -308,6 +323,198 @@ private fun historyFilters(
                         onClick = { listener.onResultSelected(filter) },
                         label = { Text(stringResource(filter.labelRes)) },
                     )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun historyGameCard(game: HistoryGame) {
+    val colors = MaterialTheme.colorScheme
+    val context = LocalContext.current
+    var expanded by rememberSaveable(game.id) { mutableStateOf(false) }
+    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "historyGameRotation")
+    val stateLabel = if (expanded) {
+        stringResource(R.string.timeline_section_state_expanded)
+    } else {
+        stringResource(R.string.timeline_section_state_collapsed)
+    }
+    val summary = stringResource(R.string.history_game_summary, game.turns.size, game.totalWords)
+    val dateLabel = remember(game.startTimestamp, game.endTimestamp, context) {
+        DateUtils.formatDateTime(
+            context,
+            game.startTimestamp,
+            DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_SHOW_TIME or DateUtils.FORMAT_ABBREV_MONTH,
+        )
+    }
+    val relativeTime = remember(game.endTimestamp) {
+        DateUtils.getRelativeTimeSpanString(
+            game.endTimestamp,
+            System.currentTimeMillis(),
+            DateUtils.MINUTE_IN_MILLIS,
+        ).toString()
+    }
+    val teams = remember(game.turns) { game.turns.map { it.team }.distinct() }
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { stateDescription = stateLabel },
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(role = Role.Button) { expanded = !expanded }
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(dateLabel, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        summary,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colors.onSurfaceVariant,
+                    )
+                    if (teams.isNotEmpty()) {
+                        Text(
+                            text = stringResource(R.string.history_game_teams_label, teams.joinToString()),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = colors.onSurfaceVariant,
+                        )
+                    }
+                    Text(
+                        relativeTime,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = colors.onSurfaceVariant,
+                    )
+                }
+                Icon(
+                    imageVector = Icons.Filled.ExpandMore,
+                    contentDescription = null,
+                    modifier = Modifier.rotate(rotation),
+                )
+            }
+            AnimatedVisibility(visible = expanded) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    HorizontalDivider()
+                    Column(
+                        modifier = Modifier.padding(horizontal = 20.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        game.turns.forEach { turn ->
+                            historyTurnCard(turn = turn)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun historyTurnCard(turn: HistoryTurn) {
+    val colors = MaterialTheme.colorScheme
+    var expanded by rememberSaveable(turn.id) { mutableStateOf(false) }
+    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "historyTurnRotation")
+    val stateLabel = if (expanded) {
+        stringResource(R.string.timeline_section_state_expanded)
+    } else {
+        stringResource(R.string.timeline_section_state_collapsed)
+    }
+    val relativeTime = remember(turn.endTimestamp) {
+        DateUtils.getRelativeTimeSpanString(
+            turn.endTimestamp,
+            System.currentTimeMillis(),
+            DateUtils.MINUTE_IN_MILLIS,
+        ).toString()
+    }
+    val correctLabel = pluralStringResource(
+        R.plurals.turn_summary_stat_correct,
+        turn.correctCount,
+        turn.correctCount,
+    )
+    val skippedLabel = pluralStringResource(
+        R.plurals.turn_summary_stat_skipped,
+        turn.skippedCount,
+        turn.skippedCount,
+    )
+    val pendingLabel = pluralStringResource(
+        R.plurals.turn_summary_stat_pending,
+        turn.missedCount,
+        turn.missedCount,
+    )
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { stateDescription = stateLabel },
+        shape = RoundedCornerShape(24.dp),
+        tonalElevation = if (expanded) 2.dp else 0.dp,
+        border = BorderStroke(1.dp, colors.outline.copy(alpha = 0.2f)),
+    ) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(role = Role.Button) { expanded = !expanded }
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Text(turn.team, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        relativeTime,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colors.onSurfaceVariant,
+                    )
+                    Text(
+                        text = listOf(correctLabel, skippedLabel, pendingLabel).joinToString(" • "),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colors.onSurfaceVariant,
+                    )
+                }
+                Icon(
+                    imageVector = Icons.Filled.ExpandMore,
+                    contentDescription = null,
+                    modifier = Modifier.rotate(rotation),
+                )
+            }
+            AnimatedVisibility(visible = expanded) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    HorizontalDivider(color = colors.outline.copy(alpha = 0.2f))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        turn.entries.forEach { entry ->
+                            historyEntryCard(
+                                entry = entry,
+                                modifier = Modifier.fillMaxWidth(),
+                                showTeam = false,
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -424,7 +631,11 @@ private fun sparkline(values: List<Float>, modifier: Modifier = Modifier) {
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun historyEntryCard(entry: TurnHistoryEntity) {
+private fun historyEntryCard(
+    entry: TurnHistoryEntity,
+    modifier: Modifier = Modifier,
+    showTeam: Boolean = true,
+) {
     val colors = MaterialTheme.colorScheme
     val visuals = when {
         entry.correct -> HistoryEntryVisuals(
@@ -458,7 +669,7 @@ private fun historyEntryCard(entry: TurnHistoryEntity) {
     val borderColor = visuals.accent.copy(alpha = 0.35f)
 
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(24.dp),
         color = containerColor,
         contentColor = colors.onSurface,
@@ -508,13 +719,140 @@ private fun historyEntryCard(entry: TurnHistoryEntity) {
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                AssistChip(onClick = {}, enabled = false, colors = chipColors, label = { Text(entry.team) })
+                if (showTeam) {
+                    AssistChip(onClick = {}, enabled = false, colors = chipColors, label = { Text(entry.team) })
+                }
                 val difficultyLabel = entry.difficulty?.let { stringResource(R.string.word_difficulty_value, it) }
                     ?: stringResource(R.string.history_filter_unknown_difficulty)
                 AssistChip(onClick = {}, enabled = false, colors = chipColors, label = { Text(difficultyLabel) })
             }
         }
     }
+}
+
+private data class HistoryGame(
+    val id: Long,
+    val startTimestamp: Long,
+    val endTimestamp: Long,
+    val turns: List<HistoryTurn>,
+) {
+    val totalWords: Int get() = turns.sumOf { it.entries.size }
+
+    fun filter(predicate: (TurnHistoryEntity) -> Boolean): HistoryGame? {
+        val filteredTurns = turns.mapNotNull { it.filter(predicate) }
+        if (filteredTurns.isEmpty()) return null
+        val start = filteredTurns.minOf { it.startTimestamp }
+        val end = filteredTurns.maxOf { it.endTimestamp }
+        return copy(startTimestamp = start, endTimestamp = end, turns = filteredTurns)
+    }
+}
+
+private data class HistoryTurn(
+    val id: Long,
+    val team: String,
+    val entries: List<TurnHistoryEntity>,
+    val startTimestamp: Long,
+    val endTimestamp: Long,
+) {
+    val totalWords: Int get() = entries.size
+    val correctCount: Int get() = entries.count { it.correct }
+    val skippedCount: Int get() = entries.count { it.skipped }
+    val missedCount: Int get() = entries.count { !it.correct && !it.skipped }
+
+    fun filter(predicate: (TurnHistoryEntity) -> Boolean): HistoryTurn? {
+        val filtered = entries.filter(predicate)
+        if (filtered.isEmpty()) return null
+        val ordered = filtered.sortedBy { it.timestamp }
+        return copy(
+            entries = ordered,
+            startTimestamp = ordered.first().timestamp,
+            endTimestamp = ordered.last().timestamp,
+        )
+    }
+}
+
+private fun groupHistoryIntoGames(history: List<TurnHistoryEntity>): List<HistoryGame> {
+    if (history.isEmpty()) return emptyList()
+    val orderedEntries = history.sortedBy { it.timestamp }
+    if (orderedEntries.isEmpty()) return emptyList()
+
+    val turns = mutableListOf<HistoryTurn>()
+    var currentEntries = mutableListOf<TurnHistoryEntity>()
+    var lastEntry: TurnHistoryEntity? = null
+
+    orderedEntries.forEach { entry ->
+        val shouldStartNewTurn = when {
+            currentEntries.isEmpty() -> false
+            entry.team != currentEntries.last().team -> true
+            lastEntry != null && entry.timestamp - (lastEntry?.timestamp ?: entry.timestamp) > TURN_BREAK_THRESHOLD_MILLIS -> true
+            else -> false
+        }
+        if (shouldStartNewTurn) {
+            turns += buildTurn(currentEntries.toList())
+            currentEntries = mutableListOf()
+        }
+        currentEntries += entry
+        lastEntry = entry
+    }
+    if (currentEntries.isNotEmpty()) {
+        turns += buildTurn(currentEntries.toList())
+    }
+
+    if (turns.isEmpty()) return emptyList()
+
+    val games = mutableListOf<HistoryGame>()
+    var currentTurns = mutableListOf<HistoryTurn>()
+    var lastTurnEnd: Long? = null
+
+    turns.forEach { turn ->
+        val shouldStartNewGame = when {
+            currentTurns.isEmpty() -> false
+            lastTurnEnd == null -> false
+            turn.startTimestamp - lastTurnEnd!! > GAME_BREAK_THRESHOLD_MILLIS -> true
+            else -> false
+        }
+        if (shouldStartNewGame) {
+            games += buildGame(currentTurns.toList())
+            currentTurns = mutableListOf()
+        }
+        currentTurns += turn
+        lastTurnEnd = turn.endTimestamp
+    }
+    if (currentTurns.isNotEmpty()) {
+        games += buildGame(currentTurns.toList())
+    }
+
+    return games.sortedByDescending { it.endTimestamp }
+}
+
+private fun buildTurn(entries: List<TurnHistoryEntity>): HistoryTurn {
+    if (entries.isEmpty()) {
+        throw IllegalArgumentException("Cannot build turn with no entries")
+    }
+    val ordered = entries.sortedBy { it.timestamp }
+    val team = ordered.first().team
+    val turnId = ordered.maxOfOrNull { it.id } ?: ordered.hashCode().toLong()
+    return HistoryTurn(
+        id = turnId,
+        team = team,
+        entries = ordered,
+        startTimestamp = ordered.first().timestamp,
+        endTimestamp = ordered.last().timestamp,
+    )
+}
+
+private fun buildGame(turns: List<HistoryTurn>): HistoryGame {
+    if (turns.isEmpty()) {
+        throw IllegalArgumentException("Cannot build game with no turns")
+    }
+    val ordered = turns.sortedBy { it.startTimestamp }
+    val gameId = ordered.maxOfOrNull { it.id } ?: ordered.hashCode().toLong()
+    return HistoryGame(
+        id = gameId,
+        startTimestamp = ordered.first().startTimestamp,
+        endTimestamp = ordered.last().endTimestamp,
+        turns = ordered,
+    )
 }
 
 @Stable

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -12,7 +12,7 @@
     <string name="quick_play_subtitle">Игра с текущими настройками</string>
     <string name="decks_subtitle">Управление и импорт колод</string>
     <string name="settings_subtitle">Время, команды, язык и другое</string>
-    <string name="history_subtitle">Недавние ходы</string>
+    <string name="history_subtitle">Недавние партии</string>
     <string name="home_hero_title_idle">Добро пожаловать в Alias</string>
     <string name="home_hero_title_playing">Матч в разгаре</string>
     <string name="home_hero_title_ready">Готовы к новому раунду?</string>
@@ -303,4 +303,9 @@
     <string name="cancel">Отмена</string>
     <string name="confirm">Подтвердить</string>
     <string name="restore">Восстановить</string>
+    <string name="history_section_recent_games">Недавние партии</string>
+    <string name="history_recent_count">%1$d из %2$d игр</string>
+    <string name="history_no_entries_for_filters">Нет игр, подходящих под фильтры.</string>
+    <string name="history_game_summary">Раундов: %1$d · Слов: %2$d</string>
+    <string name="history_game_teams_label">Команды: %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="quick_play_subtitle">Start a match with current settings</string>
     <string name="decks_subtitle">Manage and import word decks</string>
     <string name="settings_subtitle">Time, teams, language and more</string>
-    <string name="history_subtitle">Review recent turns</string>
+    <string name="history_subtitle">Review recent games</string>
     <string name="home_hero_title_idle">Welcome to Alias</string>
     <string name="home_hero_title_playing">Match in progress</string>
     <string name="home_hero_title_ready">Ready for the next round?</string>
@@ -220,7 +220,7 @@
     <string name="history_result_skipped">Skipped</string>
     <string name="history_result_missed">Pending</string>
     <string name="history_section_performance">Performance</string>
-    <string name="history_section_recent_turns">Recent turns</string>
+    <string name="history_section_recent_games">Recent games</string>
     <string name="history_hide_header">Hide filters &amp; stats</string>
     <string name="history_show_header">Show filters &amp; stats</string>
     <string name="history_reset_action">Reset history</string>
@@ -228,8 +228,10 @@
     <string name="history_reset_dialog_message">Clear all saved turns? This cannot be undone.</string>
     <string name="history_reset_dialog_confirm">Reset</string>
     <string name="history_reset_dialog_cancel">Cancel</string>
-    <string name="history_recent_count">%1$d of %2$d turns</string>
-    <string name="history_no_entries_for_filters">No turns match your filters yet.</string>
+    <string name="history_recent_count">%1$d of %2$d games</string>
+    <string name="history_no_entries_for_filters">No games match your filters yet.</string>
+    <string name="history_game_summary">%1$d turns · %2$d words</string>
+    <string name="history_game_teams_label">Teams: %1$s</string>
     <string name="history_performance_summary">%1$d/%2$d correct (%3$d%%)</string>
     <string name="installed_decks">Installed Decks</string>
     <string name="enable_all">Enable all</string>


### PR DESCRIPTION
## Summary
- restructure the history screen to group entries into games with nested turn cards and expandable word breakdowns
- add history aggregation helpers to build game and turn models and reuse word cards with optional team chips
- refresh English and Russian history strings to reflect the new game-centric layout

## Testing
- ./gradlew --console=plain spotlessCheck detekt *(fails: pre-existing formatting issues in data pack tests)*
- ./gradlew --console=plain :domain:test :data:test :app:testDebugUnitTest
- ./gradlew --console=plain :app:assembleDebug

------
https://chatgpt.com/codex/tasks/task_b_68cfbef0265c832ca6adc28933ca39a5