### PR TITLE
Improve snackbar replacement behavior

### DIFF
--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -60,23 +60,24 @@ class MainActivity : AppCompatActivity() {
                                 ev.duration
                             }
                         val job = launch {
-                            val result =
-                                snack.showSnackbar(
-                                    message = ev.message,
-                                    actionLabel = ev.actionLabel,
-                                    withDismissAction = ev.actionLabel == null,
-                                    duration = duration,
-                                )
-                            if (result == SnackbarResult.ActionPerformed) {
-                                ev.onAction?.invoke()
+                            try {
+                                val result =
+                                    snack.showSnackbar(
+                                        message = ev.message,
+                                        actionLabel = ev.actionLabel,
+                                        withDismissAction = true,
+                                        duration = duration,
+                                    )
+                                if (result == SnackbarResult.ActionPerformed) {
+                                    ev.onAction?.invoke()
+                                }
+                            } finally {
+                                if (currentSnackbarJob === this) {
+                                    currentSnackbarJob = null
+                                }
                             }
                         }
                         currentSnackbarJob = job
-                        job.invokeOnCompletion {
-                            if (currentSnackbarJob === job) {
-                                currentSnackbarJob = null
-                            }
-                        }
                     }
                 }
 

--- a/app/src/main/java/com/example/alias/MainActivity.kt
+++ b/app/src/main/java/com/example/alias/MainActivity.kt
@@ -72,7 +72,7 @@ class MainActivity : AppCompatActivity() {
                                     ev.onAction?.invoke()
                                 }
                             } finally {
-                                if (currentSnackbarJob === this) {
+                                if (currentSnackbarJob === coroutineContext[Job]) {
                                     currentSnackbarJob = null
                                 }
                             }

--- a/app/src/main/java/com/example/alias/MainViewModel.kt
+++ b/app/src/main/java/com/example/alias/MainViewModel.kt
@@ -74,7 +74,7 @@ class MainViewModel
             val actionLabel: String? = null,
             val duration: SnackbarDuration = SnackbarDuration.Short,
             val isError: Boolean = false,
-            val dismissCurrent: Boolean = false,
+            val dismissCurrent: Boolean = true,
             val onAction: (suspend () -> Unit)? = null,
         )
 


### PR DESCRIPTION
## Summary
- ensure snackbar events dismiss any in-flight message by default and clear the tracking coroutine when it finishes
- always include a dismiss control when showing snackbar actions so the user can close undo-style prompts

## Testing
- ❌ `./gradlew --console=plain spotlessCheck detekt` *(fails on pre-existing formatting issue in data/src/test)*
- ✅ `./gradlew --console=plain :domain:test :data:test :app:testDebugUnitTest`
- ✅ `./gradlew --console=plain :app:assembleDebug`


------
https://chatgpt.com/codex/tasks/task_b_68cfc11eac6c832cba751ec5ca8aa3fa