### PR TITLE
Fix lint workflow resilience and cover image validation test

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./gradlew detekt --no-daemon --console=plain
 
       - name: Upload SARIF reports
-        if: always()
+        if: ${{ always() && hashFiles('app/build/reports/detekt/detekt.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: app/build/reports/detekt/detekt.sarif

--- a/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check

--- a/data/src/test/java/com/example/alias/data/pack/PackValidatorTest.kt
+++ b/data/src/test/java/com/example/alias/data/pack/PackValidatorTest.kt
@@ -26,6 +26,11 @@ class PackValidatorTest {
         assertFailsWith<CoverImageException> { PackValidator.normalizeCoverImageUrl("ftp://example.com/image.png") }
         assertFailsWith<CoverImageException> {
             PackValidator.normalizeCoverImageUrl(
+                "***example.com/image.png",
+            )
+        }
+        assertFailsWith<CoverImageException> {
+            PackValidator.normalizeCoverImageUrl(
                 "https://user:pass@example.com/image.png",
             )
         }


### PR DESCRIPTION
## Summary
- guard the Android CI SARIF upload step so detekt reports are optional when unavailable
- extend `PackValidatorTest` with a case covering invalid cover image host formatting
- fix a missing `CircleShape` import in `RoundSummaryScreen` so Compose screens compile

## Testing
- ./gradlew spotlessCheck --console=plain
- ./gradlew detekt --console=plain
- ./gradlew :domain:test :data:test :app:testDebugUnitTest --console=plain
- ./gradlew :app:assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_b_68cfc49f3604832c85adfeadaa2ce94b