### PR TITLE
Adjust timeline summary padding

### DIFF
--- a/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
+++ b/app/src/main/java/com/example/alias/ui/game/RoundSummaryScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -209,6 +210,12 @@ private fun timelineCard(
                     modifier = Modifier.padding(horizontal = 10.dp),
                     initiallyExpanded = true,
                     contentArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(
+                        start = 16.dp,
+                        end = 16.dp,
+                        top = 16.dp,
+                        bottom = 16.dp,
+                    ),
                 ) {
                     timeline.segments.forEach { segment ->
                         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -233,6 +240,12 @@ private fun timelineCard(
                     modifier = Modifier.padding(horizontal = 10.dp),
                     initiallyExpanded = false,
                     contentArrangement = Arrangement.spacedBy(20.dp),
+                    contentPadding = PaddingValues(
+                        start = 16.dp,
+                        end = 16.dp,
+                        top = 16.dp,
+                        bottom = 16.dp,
+                    ),
                 ) {
                     scoreProgressGraph(
                         events = timeline.events,
@@ -662,7 +675,7 @@ private fun scoreProgressGraph(events: List<TimelineEvent>, modifier: Modifier =
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                    .padding(horizontal = 6.dp, vertical = 16.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
@@ -737,7 +750,7 @@ private fun scoreProgressGraph(events: List<TimelineEvent>, modifier: Modifier =
                             .fillMaxWidth()
                             .padding(top = 8.dp, end = 8.dp, bottom = 8.dp),
                     ) {
-                        val chartLeftPadding = 4.dp.toPx()
+                        val chartLeftPadding = 2.dp.toPx()
                         val chartRightPadding = 4.dp.toPx()
                         val chartTopPadding = 4.dp.toPx()
                         val chartBottomPadding = 8.dp.toPx()
@@ -919,7 +932,7 @@ private fun timeBetweenWordsGraph(events: List<TimelineEvent>, modifier: Modifie
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                    .padding(horizontal = 6.dp, vertical = 16.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
@@ -928,7 +941,7 @@ private fun timeBetweenWordsGraph(events: List<TimelineEvent>, modifier: Modifie
                     color = colors.onSurfaceVariant,
                     modifier = Modifier
                         .rotate(-90f)
-                        .padding(end = 8.dp),
+                        .padding(end = 2.dp),
                 )
                 Column(
                     modifier = Modifier
@@ -980,7 +993,7 @@ private fun timeBetweenWordsGraph(events: List<TimelineEvent>, modifier: Modifie
                             .fillMaxWidth()
                             .padding(top = 8.dp, end = 8.dp, bottom = 8.dp),
                     ) {
-                        val chartLeftPadding = 4.dp.toPx()
+                        val chartLeftPadding = 2.dp.toPx()
                         val chartRightPadding = 4.dp.toPx()
                         val chartTopPadding = 4.dp.toPx()
                         val chartBottomPadding = 8.dp.toPx()
@@ -1105,6 +1118,7 @@ private fun ExpandableSection(
     modifier: Modifier = Modifier,
     initiallyExpanded: Boolean = false,
     contentArrangement: Arrangement.Vertical = Arrangement.spacedBy(12.dp),
+    contentPadding: PaddingValues = PaddingValues(top = 12.dp),
     content: @Composable ColumnScope.() -> Unit,
 ) {
     var expanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
@@ -1161,7 +1175,7 @@ private fun ExpandableSection(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 12.dp),
+                .padding(contentPadding),
             verticalArrangement = contentArrangement,
             content = content,
         )


### PR DESCRIPTION
## Summary
- add configurable content padding to timeline expandable sections so breakdown rows and graphs align with the section styling
- tighten graph layout by reducing axis padding and canvas margins for the round summary charts

## Testing
- ./gradlew --no-daemon --console=plain spotlessCheck

------
https://chatgpt.com/codex/tasks/task_b_68cfc57d3b5c832ca3bf0e77f6b5ebf1