### PR TITLE
Expand trusted source matching for pack downloads

### DIFF
--- a/data/src/main/java/com/example/alias/data/download/PackDownloader.kt
+++ b/data/src/main/java/com/example/alias/data/download/PackDownloader.kt
@@ -87,12 +87,21 @@ class PackDownloader(
         val ports = listOf(url.port, 443)
         val allowed = settings.settings.first().trustedSources
         if (allowed.isEmpty()) return false
+        val allowedNormalized = allowed
+            .asSequence()
+            .map { it.trimEnd('/').lowercase() }
+            .toSet()
         // Accept either host-only entries or origin (scheme://host[:port]) entries
-        val origins = buildList {
-            for (port in ports) add("https://${'$'}host:${'$'}port")
+        val origins = buildSet {
             add(host)
+            add("https://$host")
+            for (port in ports.distinct()) {
+                add("https://$host:$port")
+            }
         }
-        return origins.any { it in allowed }
+        return origins.any { origin ->
+            origin.trimEnd('/').lowercase() in allowedNormalized
+        }
     }
 }
 

--- a/data/src/main/java/com/example/alias/data/download/PackDownloader.kt
+++ b/data/src/main/java/com/example/alias/data/download/PackDownloader.kt
@@ -99,9 +99,7 @@ class PackDownloader(
                 add("https://$host:$port")
             }
         }
-        return origins.any { origin ->
-            origin.trimEnd('/').lowercase() in allowedNormalized
-        }
+        return origins.any { it in allowedNormalized }
     }
 }
 

--- a/data/src/test/java/com/example/alias/data/download/PackDownloaderTest.kt
+++ b/data/src/test/java/com/example/alias/data/download/PackDownloaderTest.kt
@@ -132,6 +132,18 @@ class PackDownloaderTest {
             }
         }
     }
+
+    @Test
+    fun allows_plain_https_origin_entry() = runBlocking {
+        val payload = "trusted".toByteArray()
+        withHttpsDownloader(trustedSources = { _ -> setOf("https://localhost") }) { server, downloader ->
+            val responseBody = okio.Buffer().write(payload)
+            server.enqueue(MockResponse().setResponseCode(200).setBody(responseBody))
+            val url = server.url("/pack.json").toString().replace("http://", "https://")
+            val bytes = downloader.download(url, null)
+            assertContentEquals(payload, bytes)
+        }
+    }
 }
 
 private suspend fun withHttpsDownloader(


### PR DESCRIPTION
## Summary
- normalize trusted source entries and match canonical HTTPS origins in `PackDownloader`
- add a regression test that accepts plain `https://host` entries in the trusted set

## Testing
- ./gradlew :data:test --console=plain --no-daemon > /tmp/data-test.log && tail -n 20 /tmp/data-test.log

------
https://chatgpt.com/codex/tasks/task_b_68d002961f30832cadb796fcffa76982